### PR TITLE
Support both Digest and API key authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # PyPrusaLink
 
 Python library to interact with PrusaLink API v2.
+
+This fork adds support for Digest authentication - the method Prusa recommends for their resin printers (SL1, SL1S).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyprusalink"
-version = "1.1.0"
+version = "1.2.0"
 license     = {text = "Apache-2.0"}
 description = "Library to interact with PrusaLink v2"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
   "Topic :: Home Automation",
 ]
 dependencies = [
-  "aiohttp",
+  "httpx",
 ]
 
 [tool.setuptools]

--- a/pyprusalink/__init__.py
+++ b/pyprusalink/__init__.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from httpx import Response, AsyncClient, DigestAuth
+
+from httpx import AsyncClient, DigestAuth, Response
 
 from .const import (
     API_KEY,
@@ -15,17 +16,15 @@ from .const import (
     PASSWORD,
     USER,
 )
-
 from .types import (
-    VersionInfo,
-    PrinterInfo,
-    JobInfo,
     FileInfo,
     FilesInfo,
-    UserAuth,
-    ApiKeyAuth,
+    JobInfo,
     LinkConfiguration,
+    PrinterInfo,
+    VersionInfo,
 )
+
 
 class PrusaLinkError(Exception):
     """Base class for PrusaLink errors."""
@@ -118,14 +117,15 @@ class PrusaLink:
         async with client:
             if self.auth[AUTH_TYPE] == DIGEST_AUTH:
                 auth = DigestAuth(self.auth[USER], self.auth[PASSWORD])
-                response = await client.request(
-                    method, url, json=json, auth=auth
-                )
+                response = await client.request(method, url, json=json, auth=auth)
 
             elif self.auth[AUTH_TYPE] == API_KEY_AUTH:
                 headers = {"X-Api-Key": self.auth[API_KEY]}
                 response = await client.request(
-                    method, url, json=json, headers=headers, 
+                    method,
+                    url,
+                    json=json,
+                    headers=headers,
                 )
 
             if response.status_code == 401:

--- a/pyprusalink/__init__.py
+++ b/pyprusalink/__init__.py
@@ -4,9 +4,16 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import TypedDict
-from httpx import Response, AsyncClient
+from httpx import Response, AsyncClient, BasicAuth
 
-import httpx
+API_KEY = "apiKey"
+API_KEY_AUTH = "ApiKeyAuth"
+AUTH = "auth"
+AUTH_TYPE = "authType"
+DIGEST_AUTH = "DigestAuth"
+HOST = "host"
+PASSWORD = "password"
+USER = "user"
 
 class PrusaLinkError(Exception):
     """Base class for PrusaLink errors."""
@@ -61,14 +68,14 @@ class FilesInfo(TypedDict):
 class UserAuth(TypedDict):
     """Authentication via `user` + `password` digest"""
 
-    type: "UserAuth"
+    type: DIGEST_AUTH
     user: str
     password: str
 
 class ApiKeyAuth(TypedDict):
     """Authentication via api key"""
 
-    type: "ApiKeyAuth"
+    type: API_KEY_AUTH
     apiKey: str
 
 class LinkConfiguration(TypedDict):
@@ -76,7 +83,6 @@ class LinkConfiguration(TypedDict):
 
     host: str
     auth: UserAuth | ApiKeyAuth
-
 
 class PrusaLink:
     """Wrapper for the Prusalink API.
@@ -88,16 +94,11 @@ class PrusaLink:
     def __init__(self, client: AsyncClient, config: LinkConfiguration) -> None:
         """Initialize the PrusaLink class."""
 
-        auth = config["auth"]
+        print("pyprusalink config:", config)
 
-        if auth["type"] == "UserAuth":
-            self.password = auth["password"]
-            self.user = auth["user"]
-        if auth["type"] == "ApiKeyAuth":
-            self.apiKey = auth["apiKey"]
-        self.host = config["host"]
-        self.authType = auth["type"]
+        self.host = config[HOST]
         self.client = client
+        self.auth = config[AUTH]
 
     async def cancel_job(self) -> None:
         """Cancel the current job."""
@@ -121,37 +122,37 @@ class PrusaLink:
     async def get_version(self) -> VersionInfo:
         """Get the version."""
         async with self.request("GET", "api/version") as response:
-            return response.json()
+            return await response.json()
 
     async def get_printer(self) -> PrinterInfo:
         """Get the printer."""
         async with self.request("GET", "api/printer") as response:
-            return response.json()
+            return await response.json()
 
     async def get_job(self) -> JobInfo:
         """Get current job."""
         async with self.request("GET", "api/job") as response:
-            return response.json()
+            return await response.json()
 
     async def get_file(self, path: str) -> FileInfo:
         """Get specific file info."""
         async with self.request("GET", f"api/files{path}") as response:
-            return response.json()
+            return await response.json()
 
     async def get_files(self) -> FilesInfo:
         """Get all files."""
         async with self.request("GET", "api/files?recursive=true") as response:
-            return response.json()
+            return await response.json()
 
     async def get_small_thumbnail(self, path: str) -> bytes:
         """Get a small thumbnail."""
         async with self.request("GET", f"thumb/s{path}") as response:
-            return response.read()
+            return await response.read()
 
     async def get_large_thumbnail(self, path: str) -> bytes:
         """Get a large thumbnail."""
         async with self.request("GET", f"thumb/l{path}") as response:
-            return response.read()
+            return await response.read()
 
     @asynccontextmanager
     async def request(
@@ -161,12 +162,12 @@ class PrusaLink:
         url = f"{self.host}/{path}"
 
         auth = None
-        if self.authType == "UserAuth":
-            auth = httpx.BasicAuth(self.user, self.password)
+        if self.auth[AUTH_TYPE] == DIGEST_AUTH:
+            auth = BasicAuth(self.auth[USER], self.auth[PASSWORD])
 
         headers = {}
-        if self.authType == "ApiKeyAuth":
-            headers = {"X-Api-Key": self.apiKey}
+        if self.auth[AUTH_TYPE] == API_KEY_AUTH:
+            headers = {"X-Api-Key": self.auth[API_KEY]}
 
         client = self.client
         async with client:
@@ -174,9 +175,11 @@ class PrusaLink:
                 method, url, json=json, auth=auth, headers=headers, 
             )
 
-            if response.status_code == 401:
+            print('pyprusalink response:')
+            print(response)
+            if response.status == 401:
                 raise InvalidAuth()
-            if response.status_code == 409:
+            if response.status == 409:
                 raise Conflict()
             response.raise_for_status()
 

--- a/pyprusalink/__init__.py
+++ b/pyprusalink/__init__.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import TypedDict
-from httpx import Response
+from httpx import Response, AsyncClient
 
 import httpx
-import asyncio
 
 class PrusaLinkError(Exception):
     """Base class for PrusaLink errors."""
@@ -86,7 +85,7 @@ class PrusaLink:
     https://github.com/prusa3d/Prusa-Firmware-Buddy/blob/master/lib/WUI/link_content/basic_gets.cpp
     """
 
-    def __init__(self, config: LinkConfiguration) -> None:
+    def __init__(self, client: AsyncClient, config: LinkConfiguration) -> None:
         """Initialize the PrusaLink class."""
 
         auth = config["auth"]
@@ -98,6 +97,7 @@ class PrusaLink:
             self.apiKey = auth["apiKey"]
         self.host = config["host"]
         self.authType = auth["type"]
+        self.client = client
 
     async def cancel_job(self) -> None:
         """Cancel the current job."""
@@ -168,7 +168,7 @@ class PrusaLink:
         if self.authType == "ApiKeyAuth":
             headers = {"X-Api-Key": self.apiKey}
 
-        client = httpx.AsyncClient() 
+        client = self.client
         async with client:
             response = await client.request(
                 method, url, json=json, auth=auth, headers=headers, 

--- a/pyprusalink/__init__.py
+++ b/pyprusalink/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import TypedDict
-from httpx import Response, AsyncClient, BasicAuth
+from httpx import Response, AsyncClient, DigestAuth
 
 API_KEY = "apiKey"
 API_KEY_AUTH = "ApiKeyAuth"
@@ -122,37 +122,37 @@ class PrusaLink:
     async def get_version(self) -> VersionInfo:
         """Get the version."""
         async with self.request("GET", "api/version") as response:
-            return await response.json()
+            return response.json()
 
     async def get_printer(self) -> PrinterInfo:
         """Get the printer."""
         async with self.request("GET", "api/printer") as response:
-            return await response.json()
+            return response.json()
 
     async def get_job(self) -> JobInfo:
         """Get current job."""
         async with self.request("GET", "api/job") as response:
-            return await response.json()
+            return response.json()
 
     async def get_file(self, path: str) -> FileInfo:
         """Get specific file info."""
         async with self.request("GET", f"api/files{path}") as response:
-            return await response.json()
+            return response.json()
 
     async def get_files(self) -> FilesInfo:
         """Get all files."""
         async with self.request("GET", "api/files?recursive=true") as response:
-            return await response.json()
+            return response.json()
 
     async def get_small_thumbnail(self, path: str) -> bytes:
         """Get a small thumbnail."""
         async with self.request("GET", f"thumb/s{path}") as response:
-            return await response.read()
+            return response.read()
 
     async def get_large_thumbnail(self, path: str) -> bytes:
         """Get a large thumbnail."""
         async with self.request("GET", f"thumb/l{path}") as response:
-            return await response.read()
+            return response.read()
 
     @asynccontextmanager
     async def request(
@@ -163,7 +163,7 @@ class PrusaLink:
 
         auth = None
         if self.auth[AUTH_TYPE] == DIGEST_AUTH:
-            auth = BasicAuth(self.auth[USER], self.auth[PASSWORD])
+            auth = DigestAuth(self.auth[USER], self.auth[PASSWORD])
 
         headers = {}
         if self.auth[AUTH_TYPE] == API_KEY_AUTH:
@@ -175,11 +175,10 @@ class PrusaLink:
                 method, url, json=json, auth=auth, headers=headers, 
             )
 
-            print('pyprusalink response:')
-            print(response)
-            if response.status == 401:
+            print("pyprusalink response:", response.text)
+            if response.status_code == 401:
                 raise InvalidAuth()
-            if response.status == 409:
+            if response.status_code == 409:
                 raise Conflict()
             response.raise_for_status()
 

--- a/pyprusalink/const.py
+++ b/pyprusalink/const.py
@@ -1,0 +1,8 @@
+API_KEY = "apiKey"
+API_KEY_AUTH = "ApiKeyAuth"
+AUTH = "auth"
+AUTH_TYPE = "authType"
+DIGEST_AUTH = "DigestAuth"
+HOST = "host"
+PASSWORD = "password"
+USER = "user"

--- a/pyprusalink/types.py
+++ b/pyprusalink/types.py
@@ -1,0 +1,60 @@
+from typing import TypedDict
+
+from .const import DIGEST_AUTH, API_KEY_AUTH
+
+class VersionInfo(TypedDict):
+    """Version data."""
+
+    api: str
+    server: str
+    text: str
+    hostname: str
+
+
+class PrinterInfo(TypedDict):
+    """Printer data."""
+
+    telemetry: dict
+    temperature: dict
+    state: dict
+
+
+class JobInfo(TypedDict):
+    """Job data."""
+
+    state: str
+    job: dict | None
+
+
+class FileInfo(TypedDict):
+    """File data."""
+
+    name: str
+    origin: str
+    size: int
+    refs: dict
+
+
+class FilesInfo(TypedDict):
+    """Files data."""
+
+    files: list[FileInfo]
+
+class UserAuth(TypedDict):
+    """Authentication via `user` + `password` digest"""
+
+    type: DIGEST_AUTH
+    user: str
+    password: str
+
+class ApiKeyAuth(TypedDict):
+    """Authentication via api key"""
+
+    type: API_KEY_AUTH
+    apiKey: str
+
+class LinkConfiguration(TypedDict):
+    """Configuration shape for PrusaLink"""
+
+    host: str
+    auth: UserAuth | ApiKeyAuth

--- a/pyprusalink/types.py
+++ b/pyprusalink/types.py
@@ -1,6 +1,7 @@
 from typing import TypedDict
 
-from .const import DIGEST_AUTH, API_KEY_AUTH
+from .const import API_KEY_AUTH, DIGEST_AUTH
+
 
 class VersionInfo(TypedDict):
     """Version data."""
@@ -40,6 +41,7 @@ class FilesInfo(TypedDict):
 
     files: list[FileInfo]
 
+
 class UserAuth(TypedDict):
     """Authentication via `user` + `password` digest"""
 
@@ -47,11 +49,13 @@ class UserAuth(TypedDict):
     user: str
     password: str
 
+
 class ApiKeyAuth(TypedDict):
     """Authentication via api key"""
 
     type: API_KEY_AUTH
     apiKey: str
+
 
 class LinkConfiguration(TypedDict):
     """Configuration shape for PrusaLink"""

--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,9 @@ pkgs.mkShell {
   packages = [
     (pkgs.python3.withPackages (ps: [
       ps.httpx
+      ps.isort
+      ps.flake8
+      ps.black
     ]))
   ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  packages = [
+    (pkgs.python3.withPackages (ps: [
+      ps.httpx
+    ]))
+  ];
+}
+


### PR DESCRIPTION
I would like to integrate my Prusa SL1S into Home Assistant. Prusa supports both Digest and API key authentication but recommends Digest. Thus I've updated both `pyprusalink` and the corresponding Home Assistant component in `home-assistant/core` to allow for this.

The API change is breaking.

I intend to keep working on this for my local setup, primarily adding sensors that are useful for resin printers. Maybe you're interested in upstreaming. If so, I'll also open a PR against `home-assistant/core`.

---

I currently know of one open problem I could use help with if you'd like:

- The HASS component checks if the API version is `2` and refuses to connect to the printer otherwise. But my SL1S actually returns the following from `/api/version`:
```
{
    "api": "0.1",
    "hostname": "prusa-sl1s",
    "server": "1.1.0",
    "text": "Prusa SLA 1.0.5"
}
```
Do you have any idea why that is? Is your printer running `"api": "2.0"`?