### PR TITLE
Add NotFound error exception

### DIFF
--- a/pyprusalink/client.py
+++ b/pyprusalink/client.py
@@ -6,7 +6,7 @@ from contextlib import asynccontextmanager
 import hashlib
 
 from aiohttp import ClientResponse, ClientSession
-from pyprusalink.types import Conflict, InvalidAuth
+from pyprusalink.types import Conflict, InvalidAuth, NotFound
 
 
 class ApiClient:
@@ -81,6 +81,9 @@ class ApiClient:
 
             if response.status == 409:
                 raise Conflict()
+
+            if response.status == 404:
+                raise NotFound()
 
             response.raise_for_status()
             yield response

--- a/pyprusalink/types.py
+++ b/pyprusalink/types.py
@@ -16,6 +16,10 @@ class Conflict(PrusaLinkError):
     """Error to indicate the command hit a conflict."""
 
 
+class NotFound(PrusaLinkError):
+    """Error to indicate the requested resource was not found. (404)"""
+
+
 class Capabilities(TypedDict):
     """API Capabilities"""
 


### PR DESCRIPTION
The /v1/job API consistently indicates the presence of a thumbnail for the current print, even in cases where none actually exists.

The Idea is that we just add a NotFound exception that will be thrown on the get_file() function when the thumbnail file doesn't exist. We can then handle the error in home assistant core to not showing a thumbnail. 

Ref: https://github.com/home-assistant/core/issues/104887


Code can be tested when you slice a simple cube in Prusa Slicer, while disabling all thumbnail generation. Then start that print and run this python script:
```py
#!/bin/env python3
import aiohttp
import asyncio
from pyprusalink import PrusaLink


async def main():
    async with aiohttp.ClientSession() as session:
        api = PrusaLink(session, "http://prusaxl.fritz.box", "maker", "xy")
        job = await api.get_job()
        await api.get_file(job['file']['refs']['thumbnail'])


if __name__ == "__main__":
    asyncio.run(main())
```

This should be the output:

```txt
$ ./main.py 
Traceback (most recent call last):
  File "/home/niklas/Workspace/pyprusalink/./main.py", line 15, in <module>
    asyncio.run(main())
  File "/usr/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/niklas/Workspace/pyprusalink/./main.py", line 11, in main
    await api.get_file(job['file']['refs']['thumbnail'])
  File "/home/niklas/Workspace/pyprusalink/pyprusalink/__init__.py", line 71, in get_file
    async with self.client.request("GET", path) as response:
  File "/usr/lib/python3.11/contextlib.py", line 204, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/niklas/Workspace/pyprusalink/pyprusalink/client.py", line 86, in request
    raise NotFound()
pyprusalink.types.NotFound
```