### PR TITLE
Don't escalate connection errors

### DIFF
--- a/pyprusalink/client.py
+++ b/pyprusalink/client.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 import hashlib
 
-from httpx import AsyncClient, DigestAuth, Request, Response
+from httpx import AsyncClient, DigestAuth, Request, Response, ConnectError
 from httpx._auth import _DigestAuthChallenge
 from pyprusalink.types import Conflict, InvalidAuth, NotFound
 
@@ -66,9 +66,12 @@ class ApiClient:
         """Make a request to the PrusaLink API."""
         url = f"{self.host}{path}"
 
-        response = await self._async_client.request(
-            method, url, json=json_data, auth=self._auth
-        )
+        try:
+            response = await self._async_client.request(
+                method, url, json=json_data, auth=self._auth
+            )
+        except ConnectError:
+            raise NotFound()
 
         if response.status_code == 401:
             raise InvalidAuth()


### PR DESCRIPTION
Fixes #93 and https://github.com/home-assistant/core/issues/116218

By simply catching an httpx.ConnectError and raising `NotFound()` instead, the integration won't spam the log with python tracebacks. It still correctly tracks the state of the machine in the home assistant log:

![image](https://github.com/home-assistant-libs/pyprusalink/assets/19466442/f7c0368c-cafe-4f3b-af1d-89191dc6e236)

(Excuse my setup, it's in german. "Nicht mehr verfügbar" = "Not available anymore". "Wechselte zu Idle" = "Changed to Idle")