### PR TITLE
Add test infrastructure: pytest, pytest-asyncio, respx

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e . -r requirements-test.txt
       - name: Flake8
-        run: flake8 pyprusalink
+        run: flake8 pyprusalink tests
       - name: Black
-        run: black --check pyprusalink
+        run: black --check pyprusalink tests
       - name: isort
-        run: isort --check pyprusalink
+        run: isort --check pyprusalink tests
+      - name: Pytest
+        run: pytest tests/ --tb=short

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.claude/
 *.py[cod]
 venv
 *.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
   "Environment :: Console",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Home Automation",
 ]
 dependencies = [
@@ -67,3 +67,6 @@ forced_separate = [
     "tests",
 ]
 combine_as_imports = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,6 @@
-isort==8.0.1
 black==26.3.1
 flake8==7.3.0
+isort==8.0.1
+pytest>=8.0
+pytest-asyncio>=0.24
+respx>=0.22

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ HOST = "http://printer.local"
 
 
 @pytest.fixture
-def pl(respx_mock):
+async def pl(respx_mock):
     """Return a PrusaLink instance backed by a mocked HTTP transport."""
-    client = httpx.AsyncClient()
-    return PrusaLink(client, HOST, "maker", "password")
+    async with httpx.AsyncClient() as client:
+        yield PrusaLink(client, HOST, "maker", "password")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ HOST = "http://printer.local"
 
 
 @pytest.fixture
-def prusalink(respx_mock):
+def pl(respx_mock):
     """Return a PrusaLink instance backed by a mocked HTTP transport."""
     client = httpx.AsyncClient()
     return PrusaLink(client, HOST, "maker", "password")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Shared test fixtures."""
+
+import httpx
+from pyprusalink import PrusaLink
+import pytest
+
+HOST = "http://printer.local"
+
+
+@pytest.fixture
+def prusalink(respx_mock):
+    """Return a PrusaLink instance backed by a mocked HTTP transport."""
+    client = httpx.AsyncClient()
+    return PrusaLink(client, HOST, "maker", "password")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,89 @@
+"""Tests for ApiClient error handling and DigestAuthWorkaround."""
+
+from unittest.mock import MagicMock
+
+import httpx
+from pyprusalink import PrusaLink
+from pyprusalink.client import DigestAuthWorkaround
+from pyprusalink.types import Conflict, InvalidAuth, NotFound
+import pytest
+
+HOST = "http://printer.local"
+
+
+async def test_invalid_auth_raises(respx_mock):
+    """A 401 response without a Digest challenge raises InvalidAuth."""
+    respx_mock.get(f"{HOST}/api/v1/status").mock(return_value=httpx.Response(401))
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(InvalidAuth):
+            await PrusaLink(client, HOST, "maker", "password").get_status()
+
+
+async def test_conflict_raises(respx_mock):
+    """A 409 response raises Conflict."""
+    respx_mock.delete(f"{HOST}/api/v1/job/1").mock(return_value=httpx.Response(409))
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(Conflict):
+            await PrusaLink(client, HOST, "maker", "password").cancel_job(1)
+
+
+async def test_not_found_raises(respx_mock):
+    """A 404 response raises NotFound."""
+    respx_mock.delete(f"{HOST}/api/v1/job/1").mock(return_value=httpx.Response(404))
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(NotFound):
+            await PrusaLink(client, HOST, "maker", "password").cancel_job(1)
+
+
+def test_digest_workaround_omits_algorithm_without_qop():
+    """When the server sends no qop, the Authorization header must not include algorithm.
+
+    Old Prusa firmware (< 5.2.0) rejects Digest headers that contain an unquoted
+    algorithm parameter. The workaround builds the header manually in that case.
+    """
+    auth = DigestAuthWorkaround(username="maker", password="password")
+
+    challenge = MagicMock()
+    challenge.qop = None
+    challenge.realm = b"Printer API"
+    challenge.nonce = b"testnonce123"
+
+    request = MagicMock()
+    request.url.raw_path = b"/api/version"
+    request.method = "GET"
+
+    header = auth._build_auth_header(request, challenge)
+
+    assert header.startswith("Digest ")
+    assert "algorithm" not in header.lower()
+
+
+def test_digest_workaround_delegates_to_parent_with_qop():
+    """When qop is present the workaround delegates to the standard httpx implementation."""
+    auth = DigestAuthWorkaround(username="maker", password="password")
+
+    challenge = MagicMock()
+    challenge.qop = b"auth"
+
+    request = MagicMock()
+
+    # Parent's _build_auth_header is called when qop is not None.
+    # We verify this by patching the parent and checking it was invoked.
+    called_with = {}
+
+    original = DigestAuthWorkaround.__bases__[0]._build_auth_header
+
+    def spy(self, req, chal):
+        called_with["req"] = req
+        called_with["chal"] = chal
+        return "Digest mocked=value"
+
+    DigestAuthWorkaround.__bases__[0]._build_auth_header = spy
+    try:
+        result = auth._build_auth_header(request, challenge)
+    finally:
+        DigestAuthWorkaround.__bases__[0]._build_auth_header = original
+
+    assert called_with["req"] is request
+    assert called_with["chal"] is challenge
+    assert result == "Digest mocked=value"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,9 @@
 """Tests for ApiClient error handling and DigestAuthWorkaround."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import httpx
-from pyprusalink import PrusaLink
+from httpx import DigestAuth
 from pyprusalink.client import DigestAuthWorkaround
 from pyprusalink.types import Conflict, InvalidAuth, NotFound
 import pytest
@@ -11,28 +11,25 @@ import pytest
 HOST = "http://printer.local"
 
 
-async def test_invalid_auth_raises(respx_mock):
-    """A 401 response without a Digest challenge raises InvalidAuth."""
+async def test_invalid_auth_raises(pl, respx_mock):
+    """A 401 response raises InvalidAuth."""
     respx_mock.get(f"{HOST}/api/v1/status").mock(return_value=httpx.Response(401))
-    async with httpx.AsyncClient() as client:
-        with pytest.raises(InvalidAuth):
-            await PrusaLink(client, HOST, "maker", "password").get_status()
+    with pytest.raises(InvalidAuth):
+        await pl.get_status()
 
 
-async def test_conflict_raises(respx_mock):
+async def test_conflict_raises(pl, respx_mock):
     """A 409 response raises Conflict."""
     respx_mock.delete(f"{HOST}/api/v1/job/1").mock(return_value=httpx.Response(409))
-    async with httpx.AsyncClient() as client:
-        with pytest.raises(Conflict):
-            await PrusaLink(client, HOST, "maker", "password").cancel_job(1)
+    with pytest.raises(Conflict):
+        await pl.cancel_job(1)
 
 
-async def test_not_found_raises(respx_mock):
+async def test_not_found_raises(pl, respx_mock):
     """A 404 response raises NotFound."""
     respx_mock.delete(f"{HOST}/api/v1/job/1").mock(return_value=httpx.Response(404))
-    async with httpx.AsyncClient() as client:
-        with pytest.raises(NotFound):
-            await PrusaLink(client, HOST, "maker", "password").cancel_job(1)
+    with pytest.raises(NotFound):
+        await pl.cancel_job(1)
 
 
 def test_digest_workaround_omits_algorithm_without_qop():
@@ -67,23 +64,10 @@ def test_digest_workaround_delegates_to_parent_with_qop():
 
     request = MagicMock()
 
-    # Parent's _build_auth_header is called when qop is not None.
-    # We verify this by patching the parent and checking it was invoked.
-    called_with = {}
-
-    original = DigestAuthWorkaround.__bases__[0]._build_auth_header
-
-    def spy(self, req, chal):
-        called_with["req"] = req
-        called_with["chal"] = chal
-        return "Digest mocked=value"
-
-    DigestAuthWorkaround.__bases__[0]._build_auth_header = spy
-    try:
+    with patch.object(
+        DigestAuth, "_build_auth_header", return_value="Digest mocked=value"
+    ) as mock:
         result = auth._build_auth_header(request, challenge)
-    finally:
-        DigestAuthWorkaround.__bases__[0]._build_auth_header = original
+        mock.assert_called_once_with(request, challenge)
 
-    assert called_with["req"] is request
-    assert called_with["chal"] is challenge
     assert result == "Digest mocked=value"

--- a/tests/test_prusalink.py
+++ b/tests/test_prusalink.py
@@ -1,0 +1,157 @@
+"""Happy-path tests for PrusaLink public API methods."""
+
+import httpx
+from pyprusalink import PrusaLink
+import pytest
+
+HOST = "http://printer.local"
+
+
+@pytest.fixture
+def pl(respx_mock):
+    return PrusaLink(httpx.AsyncClient(), HOST, "maker", "password")
+
+
+async def test_get_version(pl, respx_mock):
+    respx_mock.get(f"{HOST}/api/version").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "api": "2.0.0",
+                "version": "0.7.0",
+                "printer": "1.3.1",
+                "text": "PrusaLink 0.7.0",
+                "firmware": "3.10.1-4697",
+            },
+        )
+    )
+    result = await pl.get_version()
+    assert result["api"] == "2.0.0"
+    assert result["firmware"] == "3.10.1-4697"
+
+
+async def test_get_info(pl, respx_mock):
+    respx_mock.get(f"{HOST}/api/v1/info").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "mmu": False,
+                "name": "MuadDib",
+                "location": "Arrakis",
+                "farm_mode": False,
+                "nozzle_diameter": 0.4,
+                "min_extrusion_temp": 170,
+                "serial": "CZPX4720X004XC34242",
+                "sd_ready": True,
+                "active_camera": False,
+                "hostname": "prusa.lan",
+                "port": "/dev/tty",
+                "network_error_chime": False,
+            },
+        )
+    )
+    result = await pl.get_info()
+    assert result["name"] == "MuadDib"
+    assert result["serial"] == "CZPX4720X004XC34242"
+    assert result["nozzle_diameter"] == 0.4
+
+
+async def test_get_status(pl, respx_mock):
+    respx_mock.get(f"{HOST}/api/v1/status").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "printer": {
+                    "state": "PRINTING",
+                    "temp_nozzle": 214.9,
+                    "target_nozzle": 215.0,
+                    "temp_bed": 59.5,
+                    "target_bed": 60.0,
+                    "axis_z": 0.5,
+                    "flow": 100,
+                    "speed": 100,
+                    "fan_hotend": 1200,
+                    "fan_print": 4500,
+                }
+            },
+        )
+    )
+    result = await pl.get_status()
+    assert result["printer"]["state"] == "PRINTING"
+    assert result["printer"]["temp_nozzle"] == 214.9
+
+
+async def test_get_job(pl, respx_mock):
+    respx_mock.get(f"{HOST}/api/v1/job").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": 42,
+                "state": "PRINTING",
+                "progress": 55.0,
+                "time_printing": 1200,
+                "time_remaining": 980,
+                "file": {
+                    "name": "TEST~1.gco",
+                    "display_name": "test_print.gcode",
+                    "path": "/local",
+                    "display_path": "/PrusaLink gcodes",
+                    "size": 2393142,
+                    "m_timestamp": 1648042843,
+                    "refs": {
+                        "download": None,
+                        "icon": None,
+                        "thumbnail": "/api/thumbnails/local/test.gcode.orig.png",
+                    },
+                },
+            },
+        )
+    )
+    result = await pl.get_job()
+    assert result["id"] == 42
+    assert result["progress"] == 55.0
+    assert result["file"]["display_name"] == "test_print.gcode"
+
+
+async def test_get_job_no_active_job(pl, respx_mock):
+    """When no job is running the API returns 204 and we return an empty dict."""
+    respx_mock.get(f"{HOST}/api/v1/job").mock(return_value=httpx.Response(204))
+    result = await pl.get_job()
+    assert result == {}
+
+
+async def test_get_legacy_printer(pl, respx_mock):
+    respx_mock.get(f"{HOST}/api/printer").mock(
+        return_value=httpx.Response(
+            200,
+            json={"telemetry": {"material": "PLA"}},
+        )
+    )
+    result = await pl.get_legacy_printer()
+    assert result["telemetry"]["material"] == "PLA"
+
+
+async def test_cancel_job(pl, respx_mock):
+    respx_mock.delete(f"{HOST}/api/v1/job/42").mock(return_value=httpx.Response(204))
+    await pl.cancel_job(42)  # Should not raise
+
+
+async def test_pause_job(pl, respx_mock):
+    respx_mock.put(f"{HOST}/api/v1/job/42/pause").mock(return_value=httpx.Response(204))
+    await pl.pause_job(42)
+
+
+async def test_resume_job(pl, respx_mock):
+    respx_mock.put(f"{HOST}/api/v1/job/42/resume").mock(
+        return_value=httpx.Response(204)
+    )
+    await pl.resume_job(42)
+
+
+async def test_get_file(pl, respx_mock):
+    thumbnail_bytes = b"\x89PNG\r\nfake-image-data"
+    respx_mock.get(f"{HOST}/api/thumbnails/test.png").mock(
+        return_value=httpx.Response(200, content=thumbnail_bytes)
+    )
+    result = await pl.get_file("/api/thumbnails/test.png")
+    assert result == thumbnail_bytes

--- a/tests/test_prusalink.py
+++ b/tests/test_prusalink.py
@@ -1,15 +1,8 @@
 """Happy-path tests for PrusaLink public API methods."""
 
 import httpx
-from pyprusalink import PrusaLink
-import pytest
 
 HOST = "http://printer.local"
-
-
-@pytest.fixture
-def pl(respx_mock):
-    return PrusaLink(httpx.AsyncClient(), HOST, "maker", "password")
 
 
 async def test_get_version(pl, respx_mock):


### PR DESCRIPTION
## Summary

This PR establishes a proper test suite for pyprusalink, replacing the current lint-only CI with real unit tests. It is the **first in a planned series of improvements** to both this library and the Home Assistant `prusalink` integration.

### What's included

- **`requirements-test.txt`**: adds `pytest`, `pytest-asyncio`, and `respx`
- **`pyproject.toml`**: adds `[tool.pytest.ini_options]` with `asyncio_mode = "auto"` and corrects the Python classifier versions (3.9/3.10 → 3.11/3.12 to match CI)
- **`.github/workflows/test.yml`**: extends linting to the `tests/` directory and adds a `pytest tests/` step
- **`tests/conftest.py`**: shared fixtures
- **`tests/test_client.py`**: covers `ApiClient` error handling (`InvalidAuth` on 401, `Conflict` on 409, `NotFound` on 404) and `DigestAuthWorkaround` behaviour (omits `algorithm` without `qop`, delegates to parent when `qop` is present)
- **`tests/test_prusalink.py`**: happy-path coverage for all existing `PrusaLink` public methods (`get_version`, `get_info`, `get_status`, `get_job`, `get_legacy_printer`, `cancel_job`, `pause_job`, `resume_job`, `get_file`), including the 204 no-job case

All 15 tests pass in ~0.1s.

### Planned follow-up PRs

Once this lands, the next PRs in the series will:

1. **Remove `DigestAuthWorkaround`** — both upstream issues are now resolved (httpx 0.27.0, Feb 2024; Prusa firmware 5.2.0, Feb 2024). The workaround can be dropped once firmware 5.2.0+ is the minimum supported version.
2. **Add `continue_job()`** — the missing complement to `pause_job`/`resume_job` for timelapse workflows.
3. **Type the `meta` field** in `JobFilePrint` with a proper `PrintFileMetadata` TypedDict, exposing filament type, material name, estimated usage, layer height, etc.
4. **Expose `transfer`, `storage`, and `camera`** sub-objects already returned by `GET /api/v1/status` but currently ignored.
5. **New endpoints**: `get_storage()`, `get_transfer()`, `get_camera_snapshot()`, `get_update_info()`.

The goal is to give the Home Assistant integration richer, well-typed data to work with — enabling sensors for filament type, storage free space, upload progress, live camera snapshots, and firmware update availability.

## Test plan

- [x] `pytest tests/ -v` — 15 passed
- [x] `flake8 pyprusalink tests` — no errors
- [x] `black --check pyprusalink tests` — no reformats needed
- [x] `isort --check pyprusalink tests` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)