### PR TITLE
Remove DigestAuthWorkaround, require Prusa firmware 5.2.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # PyPrusaLink
 
 Python library to interact with PrusaLink API v2.
+
+## Requirements
+
+- Python 3.11+
+- Prusa firmware **5.2.0 or newer** is required. Earlier firmware versions contain a bug
+  in HTTP Digest authentication that was fixed in 5.2.0 (released February 2024).
+  If you haven't upgraded in over a year, now is a good time.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
   "Topic :: Home Automation",
 ]
 dependencies = [
-  "httpx",
+  "httpx>=0.27.0",
 ]
 
 [tool.setuptools]

--- a/pyprusalink/client.py
+++ b/pyprusalink/client.py
@@ -2,49 +2,9 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-import hashlib
 
-from httpx import AsyncClient, DigestAuth, Request, Response
-from httpx._auth import _DigestAuthChallenge
+from httpx import AsyncClient, DigestAuth, Response
 from pyprusalink.types import Conflict, InvalidAuth, NotFound
-
-
-# TODO remove after the following issues are fixed (in all supported firmwares for the latter one):
-# https://github.com/encode/httpx/pull/3045
-# https://github.com/prusa3d/Prusa-Firmware-Buddy/pull/3665
-class DigestAuthWorkaround(DigestAuth):
-    """Wrapper for httpx.DigestAuth to work around a firmware issue."""
-
-    # Taken from httpx.DigestAuth and modified
-    # https://github.com/encode/httpx/blob/c6907c22034e2739c4c1af89908e3c9f90602788/httpx/_auth.py#L258
-    def _build_auth_header(
-        self, request: Request, challenge: "_DigestAuthChallenge"
-    ) -> str:
-        if challenge.qop is not None:
-            return super()._build_auth_header(request, challenge)
-
-        def digest(data: bytes) -> bytes:
-            return hashlib.md5(data).hexdigest().encode()
-
-        A1 = b":".join((self._username, challenge.realm, self._password))
-        HA1 = digest(A1)
-
-        path = request.url.raw_path
-        A2 = b":".join((request.method.encode(), path))
-        HA2 = digest(A2)
-
-        digest_data = [HA1, challenge.nonce, HA2]
-
-        format_args = {
-            "username": self._username,
-            "realm": challenge.realm,
-            "nonce": challenge.nonce,
-            "uri": path,
-            "response": digest(b":".join(digest_data)),
-            # Omitting algorithm as a work around for https://github.com/prusa3d/Prusa-Firmware-Buddy/pull/3665
-        }
-
-        return "Digest " + self._get_header_value(format_args)
 
 
 class ApiClient:
@@ -53,7 +13,7 @@ class ApiClient:
     ) -> None:
         self._async_client = async_client
         self.host = host
-        self._auth = DigestAuthWorkaround(username=username, password=password)
+        self._auth = DigestAuth(username=username, password=password)
 
     @asynccontextmanager
     async def request(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,10 +1,7 @@
-"""Tests for ApiClient error handling and DigestAuthWorkaround."""
-
-from unittest.mock import MagicMock, patch
+"""Tests for ApiClient error handling."""
 
 import httpx
-from httpx import DigestAuth
-from pyprusalink.client import DigestAuthWorkaround
+from pyprusalink.client import ApiClient
 from pyprusalink.types import Conflict, InvalidAuth, NotFound
 import pytest
 
@@ -32,42 +29,8 @@ async def test_not_found_raises(pl, respx_mock):
         await pl.cancel_job(1)
 
 
-def test_digest_workaround_omits_algorithm_without_qop():
-    """When the server sends no qop, the Authorization header must not include algorithm.
-
-    Old Prusa firmware (< 5.2.0) rejects Digest headers that contain an unquoted
-    algorithm parameter. The workaround builds the header manually in that case.
-    """
-    auth = DigestAuthWorkaround(username="maker", password="password")
-
-    challenge = MagicMock()
-    challenge.qop = None
-    challenge.realm = b"Printer API"
-    challenge.nonce = b"testnonce123"
-
-    request = MagicMock()
-    request.url.raw_path = b"/api/version"
-    request.method = "GET"
-
-    header = auth._build_auth_header(request, challenge)
-
-    assert header.startswith("Digest ")
-    assert "algorithm" not in header.lower()
-
-
-def test_digest_workaround_delegates_to_parent_with_qop():
-    """When qop is present the workaround delegates to the standard httpx implementation."""
-    auth = DigestAuthWorkaround(username="maker", password="password")
-
-    challenge = MagicMock()
-    challenge.qop = b"auth"
-
-    request = MagicMock()
-
-    with patch.object(
-        DigestAuth, "_build_auth_header", return_value="Digest mocked=value"
-    ) as mock:
-        result = auth._build_auth_header(request, challenge)
-        mock.assert_called_once_with(request, challenge)
-
-    assert result == "Digest mocked=value"
+def test_uses_standard_digest_auth():
+    """ApiClient uses httpx.DigestAuth directly, without any subclassing."""
+    async_client = httpx.AsyncClient()
+    api = ApiClient(async_client, HOST, "maker", "password")
+    assert type(api._auth) is httpx.DigestAuth


### PR DESCRIPTION
## Summary

Removes the `DigestAuthWorkaround` subclass and uses `httpx.DigestAuth` directly.
This is the second PR in a series of improvements to pyprusalink and the Home Assistant `prusalink` integration ([first PR: #154](https://github.com/home-assistant-libs/pyprusalink/pull/154)).

## Background

The workaround was introduced to handle two bugs:

| Issue | Fix released |
|---|---|
| [encode/httpx#3045](https://github.com/encode/httpx/pull/3045) — RFC 2069 Digest auth sent a malformed header | **httpx 0.27.0** (2024-02-21) |
| [prusa3d/Prusa-Firmware-Buddy#3665](https://github.com/prusa3d/Prusa-Firmware-Buddy/pull/3665) — firmware rejected unquoted `algorithm` parameter | **firmware 5.2.0** (2024-02-06) |

Both fixes are over a year old. The firmware fix was confirmed present in v5.2.0 via commit `9123619e0b` in that release's history.

## Changes

- **`pyprusalink/client.py`**: Removes `DigestAuthWorkaround` (and the now-unused `hashlib`, `Request`, `_DigestAuthChallenge` imports). `ApiClient` now sets `self._auth = DigestAuth(...)` directly.
- **`pyproject.toml`**: Pins `httpx>=0.27.0` to ensure the fixed version is always used.
- **`README.md`**: Documents the firmware 5.2.0 minimum requirement.
- **`tests/test_client.py`**: Replaces the two workaround behaviour tests with a single assertion that `type(api._auth) is httpx.DigestAuth`.

## Test plan

- [x] `pytest tests/ -v` — 14 passed
- [x] `flake8 pyprusalink tests` — no errors
- [x] `black --check pyprusalink tests` — no reformats needed
- [x] `isort --check pyprusalink tests` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)