### PR TITLE
Add continue_job() to complete job lifecycle control

### DIFF
--- a/pyprusalink/__init__.py
+++ b/pyprusalink/__init__.py
@@ -38,6 +38,11 @@ class PrusaLink:
         async with self.client.request("PUT", f"/api/v1/job/{jobId}/resume"):
             pass
 
+    async def continue_job(self, jobId: int) -> None:
+        """Continue a job after a timelapse capture."""
+        async with self.client.request("PUT", f"/api/v1/job/{jobId}/continue"):
+            pass
+
     async def get_version(self) -> VersionInfo:
         """Get the version."""
         async with self.client.request("GET", "/api/version") as response:

--- a/tests/test_prusalink.py
+++ b/tests/test_prusalink.py
@@ -141,6 +141,13 @@ async def test_resume_job(pl, respx_mock):
     await pl.resume_job(42)
 
 
+async def test_continue_job(pl, respx_mock):
+    respx_mock.put(f"{HOST}/api/v1/job/42/continue").mock(
+        return_value=httpx.Response(204)
+    )
+    await pl.continue_job(42)
+
+
 async def test_get_file(pl, respx_mock):
     thumbnail_bytes = b"\x89PNG\r\nfake-image-data"
     respx_mock.get(f"{HOST}/api/thumbnails/test.png").mock(


### PR DESCRIPTION
## Summary

The PrusaLink API exposes four job-control endpoints, but only three were implemented:

| Method | Endpoint | Status |
|---|---|---|
| `cancel_job()` | `DELETE /api/v1/job/{id}` | ✅ existing |
| `pause_job()` | `PUT /api/v1/job/{id}/pause` | ✅ existing |
| `resume_job()` | `PUT /api/v1/job/{id}/resume` | ✅ existing |
| `continue_job()` | `PUT /api/v1/job/{id}/continue` | ➕ this PR |

`continue_job()` is needed to resume printing after a timelapse snapshot is captured. Without it, a timelapse-enabled print job cannot be unblocked programmatically.

This is the third PR in a series of improvements to pyprusalink and the Home Assistant `prusalink` integration ([#154](https://github.com/home-assistant-libs/pyprusalink/pull/154), [#155](https://github.com/home-assistant-libs/pyprusalink/pull/155)).

## Changes

- **`pyprusalink/__init__.py`**: adds `continue_job(jobId: int) -> None`
- **`tests/test_prusalink.py`**: adds `test_continue_job`

## Test plan

- [x] `pytest tests/ -v` — 16 passed
- [x] `flake8 pyprusalink tests` — no errors
- [x] `black --check pyprusalink tests` — no reformats needed
- [x] `isort --check pyprusalink tests` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)