### PR TITLE
Expose job and storage sub-objects from /api/v1/status

### DIFF
--- a/pyprusalink/types.py
+++ b/pyprusalink/types.py
@@ -96,12 +96,15 @@ class PrinterStatusInfo(TypedDict):
 
 
 class StatusJob(TypedDict, total=False):
-    """Job summary embedded in the status response."""
+    """Job summary embedded in the status response.
+
+    All fields are optional per the OpenAPI spec.
+    """
 
     id: int
     progress: float
     time_printing: int
-    time_remaining: int | None
+    time_remaining: int
 
 
 class StatusStorage(TypedDict):
@@ -110,14 +113,15 @@ class StatusStorage(TypedDict):
     path: str
     name: str
     read_only: bool
+    free_space: NotRequired[int]
 
 
 class PrinterStatus(TypedDict):
     """Printer status."""
 
     printer: PrinterStatusInfo
-    job: NotRequired[StatusJob | None]
-    storage: NotRequired[StatusStorage | None]
+    job: NotRequired[StatusJob]
+    storage: NotRequired[StatusStorage]
 
 
 class PrintFileRefs(TypedDict):

--- a/pyprusalink/types.py
+++ b/pyprusalink/types.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 """Types of the v1 API. Source: https://github.com/prusa3d/Prusa-Link-Web/blob/master/spec/openapi.yaml"""
 
@@ -95,10 +95,29 @@ class PrinterStatusInfo(TypedDict):
     status_connect: StatusInfo | None
 
 
+class StatusJob(TypedDict, total=False):
+    """Job summary embedded in the status response."""
+
+    id: int
+    progress: float
+    time_printing: int
+    time_remaining: int | None
+
+
+class StatusStorage(TypedDict):
+    """Active storage device embedded in the status response."""
+
+    path: str
+    name: str
+    read_only: bool
+
+
 class PrinterStatus(TypedDict):
     """Printer status."""
 
     printer: PrinterStatusInfo
+    job: NotRequired[StatusJob | None]
+    storage: NotRequired[StatusStorage | None]
 
 
 class PrintFileRefs(TypedDict):

--- a/tests/test_prusalink.py
+++ b/tests/test_prusalink.py
@@ -76,6 +76,7 @@ async def test_get_status(pl, respx_mock):
                     "path": "/usb/",
                     "name": "usb",
                     "read_only": False,
+                    "free_space": 4202335,
                 },
             },
         )
@@ -86,6 +87,7 @@ async def test_get_status(pl, respx_mock):
     assert result["job"]["id"] == 42
     assert result["job"]["time_remaining"] == 980
     assert result["storage"]["name"] == "usb"
+    assert result["storage"]["free_space"] == 4202335
 
 
 async def test_get_status_idle(pl, respx_mock):

--- a/tests/test_prusalink.py
+++ b/tests/test_prusalink.py
@@ -65,13 +65,58 @@ async def test_get_status(pl, respx_mock):
                     "speed": 100,
                     "fan_hotend": 1200,
                     "fan_print": 4500,
-                }
+                },
+                "job": {
+                    "id": 42,
+                    "progress": 55.0,
+                    "time_printing": 1200,
+                    "time_remaining": 980,
+                },
+                "storage": {
+                    "path": "/usb/",
+                    "name": "usb",
+                    "read_only": False,
+                },
             },
         )
     )
     result = await pl.get_status()
     assert result["printer"]["state"] == "PRINTING"
     assert result["printer"]["temp_nozzle"] == 214.9
+    assert result["job"]["id"] == 42
+    assert result["job"]["time_remaining"] == 980
+    assert result["storage"]["name"] == "usb"
+
+
+async def test_get_status_idle(pl, respx_mock):
+    """In IDLE state the job key is absent from the response."""
+    respx_mock.get(f"{HOST}/api/v1/status").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "printer": {
+                    "state": "IDLE",
+                    "temp_nozzle": 27.6,
+                    "target_nozzle": 0.0,
+                    "temp_bed": 24.3,
+                    "target_bed": 0.0,
+                    "axis_z": 0.0,
+                    "flow": 100,
+                    "speed": 100,
+                    "fan_hotend": 0,
+                    "fan_print": 0,
+                },
+                "storage": {
+                    "path": "/usb/",
+                    "name": "usb",
+                    "read_only": False,
+                },
+            },
+        )
+    )
+    result = await pl.get_status()
+    assert result["printer"]["state"] == "IDLE"
+    assert "job" not in result
 
 
 async def test_get_job(pl, respx_mock):


### PR DESCRIPTION
## Summary

`PrinterStatus` previously only typed the `printer` key. The `/api/v1/status` endpoint also returns:

- `job` — present while printing, absent in IDLE (typed with `NotRequired`)
- `storage` — the active storage device

Both are useful for consumers who want to poll a single endpoint instead of combining `/api/v1/status` and `/api/v1/job`.

New types added to `types.py`:
- `StatusJob` — job summary as it appears in the status response
- `StatusStorage` — storage device as it appears in the status response

## Verification

Verified the actual response structure against a live Core One printer (firmware 6.5.3) in both IDLE and PRINTING states. The `job` key is genuinely absent (not null) when no job is running, hence `NotRequired` rather than `| None`.

## Test plan
- [ ] `test_get_status` — asserts `job` and `storage` fields during printing
- [ ] `test_get_status_idle` — asserts `job` key is absent in IDLE response

🤖 Generated with [Claude Code](https://claude.com/claude-code)