### PR TITLE
Add get_storage() to query available storage devices

### DIFF
--- a/pyprusalink/__init__.py
+++ b/pyprusalink/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from httpx import AsyncClient
 from pyprusalink.client import ApiClient
-from pyprusalink.types import JobInfo, PrinterInfo, PrinterStatus, VersionInfo
+from pyprusalink.types import JobInfo, PrinterInfo, PrinterStatus, Storage, VersionInfo
 from pyprusalink.types_legacy import LegacyPrinterStatus
 
 
@@ -70,6 +70,11 @@ class PrusaLink:
             if response.status_code == 204:
                 return {}
             return response.json()
+
+    async def get_storage(self) -> list[Storage]:
+        """Get available storage devices."""
+        async with self.client.request("GET", "/api/v1/storage") as response:
+            return response.json()["storage_list"]
 
     # Prusa Link Web UI still uses the old endpoints and it seems that the new v1 endpoint doesn't support this yet
     async def get_file(self, path: str) -> bytes:

--- a/pyprusalink/types.py
+++ b/pyprusalink/types.py
@@ -133,3 +133,17 @@ class JobInfo(TypedDict):
     inaccurate_estimates: bool | None
     serial_print: bool | None
     file: JobFilePrint | None
+
+
+class Storage(TypedDict, total=False):
+    """A storage device returned by /api/v1/storage."""
+
+    name: str
+    type: str
+    path: str
+    read_only: bool
+    available: bool
+    free_space: int
+    total_space: int
+    print_files: int
+    system_files: int

--- a/pyprusalink/types.py
+++ b/pyprusalink/types.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 """Types of the v1 API. Source: https://github.com/prusa3d/Prusa-Link-Web/blob/master/spec/openapi.yaml"""
 
@@ -135,15 +135,15 @@ class JobInfo(TypedDict):
     file: JobFilePrint | None
 
 
-class Storage(TypedDict, total=False):
+class Storage(TypedDict):
     """A storage device returned by /api/v1/storage."""
 
-    name: str
     type: str
     path: str
-    read_only: bool
     available: bool
-    free_space: int
-    total_space: int
-    print_files: int
-    system_files: int
+    name: NotRequired[str]
+    read_only: NotRequired[bool]
+    free_space: NotRequired[int]
+    total_space: NotRequired[int]
+    print_files: NotRequired[int]
+    system_files: NotRequired[int]

--- a/tests/test_prusalink.py
+++ b/tests/test_prusalink.py
@@ -148,6 +148,32 @@ async def test_continue_job(pl, respx_mock):
     await pl.continue_job(42)
 
 
+async def test_get_storage(pl, respx_mock):
+    respx_mock.get(f"{HOST}/api/v1/storage").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "storage_list": [
+                    {
+                        "name": "usb",
+                        "type": "USB",
+                        "path": "/usb/",
+                        "read_only": False,
+                        "available": True,
+                        "free_space": 14123456789,
+                        "total_space": 16000000000,
+                    }
+                ]
+            },
+        )
+    )
+    result = await pl.get_storage()
+    assert len(result) == 1
+    assert result[0]["name"] == "usb"
+    assert result[0]["type"] == "USB"
+    assert result[0]["available"] is True
+
+
 async def test_get_file(pl, respx_mock):
     thumbnail_bytes = b"\x89PNG\r\nfake-image-data"
     respx_mock.get(f"{HOST}/api/thumbnails/test.png").mock(


### PR DESCRIPTION
## Summary

Adds `get_storage() -> list[Storage]` wrapping `GET /api/v1/storage`.

The new `Storage` TypedDict mirrors the OpenAPI [Storage schema](https://github.com/prusa3d/Prusa-Link-Web/blob/master/spec/openapi.yaml):
- **Required:** `type`, `path`, `available`
- **Optional:** `name`, `read_only`, `free_space`, `total_space`, `print_files`, `system_files`

## Test plan
- [x] `test_get_storage` — verifies the `storage_list` is unwrapped and returned as a list

🤖 Generated with [Claude Code](https://claude.com/claude-code)