### PR TITLE
Fix VersionInfo to match real /api/version responses

### DIFF
--- a/pyprusalink/types.py
+++ b/pyprusalink/types.py
@@ -27,13 +27,33 @@ class Capabilities(TypedDict):
 
 
 class VersionInfo(TypedDict):
-    """Version data."""
+    """Version data from /api/version.
+
+    Field availability differs between PrusaLink variants and firmware versions:
+
+    Bundled PrusaLink (Prusa-Firmware-Buddy, all printers):
+      Always returned: api, server, nozzle_diameter, text, hostname, capabilities
+      Returned on v6.5.1+ only: firmware, printer
+        - v6.5.1 (2025-11-11): added on Core One L
+        - v6.5.3 (2026-03-24): propagated to Core One/MK4/MK3.9/MK3.5 family
+        - XL (6.4.x track) and MINI (6.4.0): not yet backported
+        - Source: https://github.com/prusa3d/Prusa-Firmware-Buddy/commit/64b7a21
+
+    Standalone PrusaLink (RPi-based installations):
+      May return version and sdk per the Prusa-Link-Web OpenAPI spec; these
+      are never returned by bundled firmware.
+
+    Use dict.get() for any field other than `api` to handle absence safely.
+    """
 
     api: str
-    version: str
-    printer: str
-    text: str
-    firmware: str
+    text: str | None
+    server: str | None
+    hostname: str | None
+    nozzle_diameter: float | None
+    firmware: str | None
+    printer: str | None
+    version: str | None
     sdk: str | None
     capabilities: Capabilities | None
 

--- a/pyprusalink/types.py
+++ b/pyprusalink/types.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 """Types of the v1 API. Source: https://github.com/prusa3d/Prusa-Link-Web/blob/master/spec/openapi.yaml"""
 
@@ -39,6 +39,11 @@ class VersionInfo(TypedDict):
         - XL (6.4.x track) and MINI (6.4.0): not yet backported
         - Source: https://github.com/prusa3d/Prusa-Firmware-Buddy/commit/64b7a21
 
+    Example response from MK4 firmware 6.4.0 (no firmware/printer fields):
+        {"api": "2.0.0", "server": "2.1.2", "nozzle_diameter": 0.4,
+         "text": "PrusaLink", "hostname": "prusa-mk4",
+         "capabilities": {"upload-by-put": True}}
+
     Standalone PrusaLink (RPi-based installations):
       May return version and sdk per the Prusa-Link-Web OpenAPI spec; these
       are never returned by bundled firmware.
@@ -47,15 +52,15 @@ class VersionInfo(TypedDict):
     """
 
     api: str
-    text: str | None
-    server: str | None
-    hostname: str | None
-    nozzle_diameter: float | None
-    firmware: str | None
-    printer: str | None
-    version: str | None
-    sdk: str | None
-    capabilities: Capabilities | None
+    text: NotRequired[str]
+    server: NotRequired[str]
+    hostname: NotRequired[str]
+    nozzle_diameter: NotRequired[float]
+    firmware: NotRequired[str]
+    printer: NotRequired[str]
+    version: NotRequired[str]
+    sdk: NotRequired[str]
+    capabilities: NotRequired[Capabilities]
 
 
 class PrinterInfo(TypedDict):

--- a/tests/test_prusalink.py
+++ b/tests/test_prusalink.py
@@ -6,21 +6,47 @@ HOST = "http://printer.local"
 
 
 async def test_get_version(pl, respx_mock):
+    """Modern firmware (Buddy v6.5.1+) returns firmware and printer fields."""
     respx_mock.get(f"{HOST}/api/version").mock(
         return_value=httpx.Response(
             200,
             json={
                 "api": "2.0.0",
-                "version": "0.7.0",
-                "printer": "1.3.1",
-                "text": "PrusaLink 0.7.0",
-                "firmware": "3.10.1-4697",
+                "server": "2.1.2",
+                "nozzle_diameter": 0.40,
+                "text": "PrusaLink",
+                "hostname": "prusa-core-one",
+                "firmware": "6.5.3+12780",
+                "printer": "7.1.0",
+                "capabilities": {"upload-by-put": True},
             },
         )
     )
     result = await pl.get_version()
     assert result["api"] == "2.0.0"
-    assert result["firmware"] == "3.10.1-4697"
+    assert result["firmware"] == "6.5.3+12780"
+    assert result["printer"] == "7.1.0"
+
+
+async def test_get_version_legacy_firmware(pl, respx_mock):
+    """Legacy firmware (Buddy <v6.5.1, XL, MINI) omits firmware and printer fields."""
+    respx_mock.get(f"{HOST}/api/version").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "api": "2.0.0",
+                "server": "2.1.2",
+                "nozzle_diameter": 0.40,
+                "text": "PrusaLink",
+                "hostname": "prusa-mk39",
+                "capabilities": {"upload-by-put": True},
+            },
+        )
+    )
+    result = await pl.get_version()
+    assert result["api"] == "2.0.0"
+    assert result.get("firmware") is None
+    assert result.get("printer") is None
 
 
 async def test_get_info(pl, respx_mock):

--- a/tests/test_prusalink.py
+++ b/tests/test_prusalink.py
@@ -45,8 +45,8 @@ async def test_get_version_legacy_firmware(pl, respx_mock):
     )
     result = await pl.get_version()
     assert result["api"] == "2.0.0"
-    assert result.get("firmware") is None
-    assert result.get("printer") is None
+    assert "firmware" not in result
+    assert "printer" not in result
 
 
 async def test_get_info(pl, respx_mock):


### PR DESCRIPTION
## Summary

`VersionInfo` listed fields as required that the bundled PrusaLink in Prusa-Firmware-Buddy never returns (`version`, `sdk`) or only returns conditionally (`firmware`, `printer`). It also omitted three fields the bundled firmware always returns (`server`, `hostname`, `nozzle_diameter`).

## Field availability matrix

`firmware` and `printer` were added to bundled PrusaLink in [`64b7a21`](https://github.com/prusa3d/Prusa-Firmware-Buddy/commit/64b7a21) (BFW-7864):

| Firmware | Has `firmware`/`printer` |
|----------|--------------------------|
| ≤ v6.5.0 | ❌ |
| v6.4.1 (XL track) | ❌ (not backported) |
| v6.5.1 (Core One L) | ✅ |
| v6.5.2 (Core One L) | ✅ |
| v6.5.3 (Core One/MK4/MK3.9/MK3.5 family) | ✅ |

Models still without the fields on their latest firmware: **XL** (6.4.x), **MINI** (last release 6.4.0).

`version` and `sdk` are in the [Prusa-Link-Web OpenAPI spec](https://github.com/prusa3d/Prusa-Link-Web/blob/master/spec/openapi.yaml) but never returned by bundled firmware — kept as optional in case standalone PrusaLink (RPi) returns them.

## Changes

- `pyprusalink/types.py`: every field on `VersionInfo` except `api` is now optional. Added docstring documenting which firmware versions return which fields.
- `tests/test_prusalink.py`: updated `test_get_version` to use realistic Core One 6.5.3 data; added `test_get_version_legacy_firmware` covering the case where the printer doesn't return `firmware`/`printer`.

## Test plan
- [x] Unit tests pass: `pytest tests/`
- [x] Lint clean: flake8 / black / isort
- [x] Verified against Core One firmware 6.5.3 — modern fields present
- [x] @agners reported MK3.9/6.4.0 lacks `firmware` field — confirmed via firmware source code analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)