### PR TITLE
Consolidate test dependencies into pyproject.toml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e . -r requirements-test.txt
+          pip install -e ".[test,lint]"
       - name: Flake8
         run: flake8 pyprusalink tests
       - name: Black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,14 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-  "pytest>=8.0",
-  "pytest-asyncio>=0.24",
-  "respx>=0.22",
+  "pytest>=9.0.3",
+  "pytest-asyncio>=1.3.0",
+  "respx>=0.23.1",
+]
+lint = [
+  "black==26.3.1",
+  "flake8==7.3.0",
+  "isort==8.0.1",
 ]
 
 [tool.setuptools]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,0 @@
-black==26.3.1
-flake8==7.3.0
-isort==8.0.1
-pytest>=9.0.3
-pytest-asyncio>=1.3.0
-respx>=0.23.1


### PR DESCRIPTION
## Summary

Removes the divergence between `requirements-test.txt` and `[project.optional-dependencies]` flagged by @agners on #157.

- Moves test runtime deps to `[project.optional-dependencies] test` (pytest, pytest-asyncio, respx)
- Adds `[project.optional-dependencies] lint` for the linters (black, flake8, isort) — same exact pins as before
- Deletes `requirements-test.txt`
- CI workflow now installs via `pip install -e .[test,lint]`

Versions match what was in `requirements-test.txt` after the recent dependabot bumps (#162, #163, #164).

## Test plan
- [x] `pip install -e .[test,lint]` resolves cleanly
- [x] `pytest tests/` — 18 passed, 5 deselected
- [x] flake8 / black / isort all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)