### PR TITLE
Add mypy strict + tighten get_job() to JobInfo | None + py.typed marker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,5 +36,7 @@ jobs:
         run: black --check pyprusalink tests
       - name: isort
         run: isort --check pyprusalink tests
+      - name: mypy
+        run: mypy
       - name: Pytest
         run: pytest tests/ --tb=short

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ lint = [
 
 [tool.setuptools]
 platforms = ["any"]
-zip-safe  = false
 include-package-data = true
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ lint = [
   "black==26.3.1",
   "flake8==7.3.0",
   "isort==8.0.1",
+  "mypy==2.0.0",
 ]
 
 [tool.setuptools]
@@ -84,3 +85,8 @@ combine_as_imports = true
 asyncio_mode = "auto"
 markers = ["integration: requires a real PrusaLink printer (skipped in CI)"]
 addopts = "-m 'not integration'"
+
+[tool.mypy]
+python_version = "3.11"
+packages = ["pyprusalink"]
+strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,11 +38,14 @@ lint = [
 
 [tool.setuptools]
 platforms = ["any"]
-zip-safe  = true
+zip-safe  = false
 include-package-data = true
 
 [tool.setuptools.packages.find]
 include = ["pyprusalink*"]
+
+[tool.setuptools.package-data]
+pyprusalink = ["py.typed"]
 
 
 [tool.pylint.BASIC]

--- a/pyprusalink/__init__.py
+++ b/pyprusalink/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 from httpx import AsyncClient
 from pyprusalink.client import ApiClient
 from pyprusalink.types import (
@@ -53,42 +55,42 @@ class PrusaLink:
     async def get_version(self) -> VersionInfo:
         """Get the version."""
         async with self.client.request("GET", "/api/version") as response:
-            return response.json()
+            return cast(VersionInfo, response.json())
 
     async def get_legacy_printer(self) -> LegacyPrinterStatus:
         """Get the legacy printer endpoint."""
         async with self.client.request("GET", "/api/printer") as response:
-            return response.json()
+            return cast(LegacyPrinterStatus, response.json())
 
     async def get_info(self) -> PrinterInfo:
         """Get the printer."""
         async with self.client.request("GET", "/api/v1/info") as response:
-            return response.json()
+            return cast(PrinterInfo, response.json())
 
     async def get_status(self) -> PrinterStatus:
         """Get the printer."""
         async with self.client.request("GET", "/api/v1/status") as response:
-            return response.json()
+            return cast(PrinterStatus, response.json())
 
     async def get_job(self) -> JobInfo:
         """Get current job."""
         async with self.client.request("GET", "/api/v1/job") as response:
             # when there is no job running we'll an empty document that will fail to parse
             if response.status_code == 204:
-                return {}
-            return response.json()
+                return cast(JobInfo, {})
+            return cast(JobInfo, response.json())
 
     async def get_storage(self) -> list[Storage]:
         """Get available storage devices."""
         async with self.client.request("GET", "/api/v1/storage") as response:
-            return response.json()["storage_list"]
+            return cast(list[Storage], response.json()["storage_list"])
 
     async def get_transfer(self) -> Transfer | None:
         """Get active transfer. Returns None when no transfer is in progress."""
         async with self.client.request("GET", "/api/v1/transfer") as response:
             if response.status_code == 204:
                 return None
-            return response.json()
+            return cast(Transfer, response.json())
 
     async def cancel_transfer(self, transfer_id: int) -> None:
         """Cancel the transfer with the given id."""

--- a/pyprusalink/__init__.py
+++ b/pyprusalink/__init__.py
@@ -72,12 +72,11 @@ class PrusaLink:
         async with self.client.request("GET", "/api/v1/status") as response:
             return cast(PrinterStatus, response.json())
 
-    async def get_job(self) -> JobInfo:
-        """Get current job."""
+    async def get_job(self) -> JobInfo | None:
+        """Get current job. Returns None when no job is running."""
         async with self.client.request("GET", "/api/v1/job") as response:
-            # when there is no job running we'll an empty document that will fail to parse
             if response.status_code == 204:
-                return cast(JobInfo, {})
+                return None
             return cast(JobInfo, response.json())
 
     async def get_storage(self) -> list[Storage]:

--- a/pyprusalink/client.py
+++ b/pyprusalink/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 import hashlib
+from typing import Any
 
 from httpx import AsyncClient, DigestAuth, Request, Response
 from httpx._auth import _DigestAuthChallenge
@@ -60,7 +61,7 @@ class ApiClient:
         self,
         method: str,
         path: str,
-        json_data: dict | None = None,
+        json_data: dict[str, Any] | None = None,
         try_auth: bool = True,
     ) -> AsyncGenerator[Response, None]:
         """Make a request to the PrusaLink API."""

--- a/pyprusalink/types.py
+++ b/pyprusalink/types.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import NotRequired, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 """Types of the v1 API. Source: https://github.com/prusa3d/Prusa-Link-Web/blob/master/spec/openapi.yaml"""
 
@@ -166,7 +166,7 @@ class JobFilePrint(TypedDict):
     display_path: str | None
     size: int | None
     m_timestamp: int
-    meta: dict | None
+    meta: dict[str, Any] | None
     refs: PrintFileRefs | None
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -50,9 +50,9 @@ async def test_get_status(printer):
 
 async def test_get_job(printer):
     result = await printer.get_job()
-    # Returns empty dict when no job is running — both states are valid
-    assert isinstance(result, dict)
-    if result:
+    # Returns None when no job is running — both states are valid
+    assert result is None or isinstance(result, dict)
+    if result is not None:
         assert "id" in result
         assert "state" in result
 

--- a/tests/test_prusalink.py
+++ b/tests/test_prusalink.py
@@ -180,10 +180,10 @@ async def test_get_job(pl, respx_mock):
 
 
 async def test_get_job_no_active_job(pl, respx_mock):
-    """When no job is running the API returns 204 and we return an empty dict."""
+    """When no job is running the API returns 204 and we return None."""
     respx_mock.get(f"{HOST}/api/v1/job").mock(return_value=httpx.Response(204))
     result = await pl.get_job()
-    assert result == {}
+    assert result is None
 
 
 async def test_get_legacy_printer(pl, respx_mock):


### PR DESCRIPTION
## Summary

Adds `mypy --strict` as a CI step, fixes the type-soundness issues it surfaces, and addresses two correctness gaps caught in review.

The library declared correct TypedDict return types on its public methods, but the implementations all returned `Any` (the result of `response.json()`). Mypy is lenient with `Any → TypedDict` so the leak was invisible, but `Any → list[Storage]` (added in 2.2.0) is strict — that's how the issue surfaced when wiring up the new `get_storage()` method downstream in Home Assistant core. Every other GET method had the same latent flaw.

## Why now

We discovered this while writing the storage-sensors integration in HA. Without fixing it at the source, every downstream consumer would have to `cast()` results back into the declared types — type debt distributed across consumers. Cleaner to fix once at the boundary.

## `get_job()` signature change (review feedback)

The original code did `cast(JobInfo, {})` on the 204 branch, which lies to the type checker — an empty dict does not satisfy `JobInfo`'s required keys. Changed to `JobInfo | None`, returning `None` on 204. This matches the existing `get_transfer() -> Transfer | None` pattern.

This is a minor breaking change at the type level. Runtime impact for sane consumers is nil — anyone reading `job["progress"]` on the empty-dict return was already crashing today; the new contract just makes the no-job state explicit. HA-side will need a one-line `data is not None` guard in its base entity's `available` check; that change rides along with the eventual 2.2.1 bump there.

## `py.typed` marker (review feedback)

Adding `pyprusalink/py.typed` (PEP 561) so downstream type checkers actually see the TypedDicts. Without it, the strict-typing work in this PR is invisible to consumers — installed distributions would be treated as untyped. Includes:
- empty `pyprusalink/py.typed` (full typing marker)
- `[tool.setuptools.package-data] pyprusalink = ["py.typed"]` to ensure inclusion in the wheel
- `zip-safe = false` per setuptools/mypy guidance for typed packages

## Why `cast()` (and not pydantic / msgspec / TypeGuards)

`cast()` at each return site is the pragmatic choice for a thin API wrapper:

| Approach | Decision |
|---|---|
| **`cast()`** | ✅ Chosen. Dominant HA-ecosystem pattern, zero runtime cost, minimal change. |
| **pydantic / msgspec** | ❌ Overkill for a thin wrapper. Pulls in a ~50KB+ C extension and requires refactoring the public types. |
| **Custom TypeGuards** | ❌ Maintenance burden, easy to drift from the TypedDict definitions. |
| **Suppress with `# type: ignore`** | ❌ Defers the debt without solving anything. |

Trade-off accepted: `cast()` does not validate at runtime. If the Prusa API ever changes shape, errors surface as `KeyError`/`AttributeError` in consumer code rather than at the library boundary. For a stable upstream API this is acceptable; runtime validation can be layered on later without changing the public types.

## Why strict from the start

`--strict` rather than gradual tightening: with only 10 errors on a small codebase, fixing them in one pass is cheaper than introducing a slow ratchet. Strict mode then prevents future contributions from quietly weakening typing — any new method that leaks `Any` will fail CI.

## Changes

- `pyproject.toml`: `mypy==2.0.0` in `lint` extras; `[tool.mypy] strict = true`; `package-data` for `py.typed`; `zip-safe = false`
- `.github/workflows/test.yml`: new `mypy` step
- `pyprusalink/py.typed`: PEP 561 marker (new, empty)
- `pyprusalink/__init__.py`: `cast(...)` at each `response.json()` return; `get_job() -> JobInfo | None` returning `None` on 204
- `pyprusalink/types.py`: `dict | None` → `dict[str, Any] | None` on `JobFilePrint.meta`
- `pyprusalink/client.py`: same `dict[str, Any]` fix on `request(..., json_data=...)`
- `tests/`: updated `get_job` no-job assertion from `== {}` to `is None`

## Suggested release

Suggesting **2.2.1** as a patch release once this lands. Runtime is fully backward compatible for sane consumers; the typing contract becomes more honest. HA core will bump to 2.2.1 in a follow-up PR that also adds the small `data is not None` guard.

## Test plan
- [x] `mypy` — Success: no issues found in 4 source files
- [x] `pytest tests/` — 22 passed
- [x] flake8 / black / isort all clean
- [x] Wheel build verified to include `pyprusalink/py.typed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)