### PR TITLE
Migrate PrinterInfo fields from T | None to NotRequired[T]

### DIFF
--- a/pyprusalink/types.py
+++ b/pyprusalink/types.py
@@ -64,20 +64,29 @@ class VersionInfo(TypedDict):
 
 
 class PrinterInfo(TypedDict):
-    """Printer informations."""
+    """Printer information from /api/v1/info.
 
-    mmu: bool | None
-    name: str | None
-    location: str | None
-    farm_mode: bool | None
-    nozzle_diameter: float | None
-    min_extrusion_temp: int | None
-    serial: str | None
-    sd_ready: bool | None
-    active_camera: bool | None
-    hostname: str | None
-    port: str | None
-    network_error_chime: bool | None
+    The set of fields returned varies by firmware version and printer
+    model — older firmware may omit fields like `min_extrusion_temp` or
+    `network_error_chime`, and a Buddy printer not in farm mode may omit
+    `farm_mode`. Treat any missing key as "not reported", not
+    "false/zero/empty".
+
+    Use `dict.get()` or `key in info` rather than indexing.
+    """
+
+    mmu: NotRequired[bool]
+    name: NotRequired[str]
+    location: NotRequired[str]
+    farm_mode: NotRequired[bool]
+    nozzle_diameter: NotRequired[float]
+    min_extrusion_temp: NotRequired[int]
+    serial: NotRequired[str]
+    sd_ready: NotRequired[bool]
+    active_camera: NotRequired[bool]
+    hostname: NotRequired[str]
+    port: NotRequired[str]
+    network_error_chime: NotRequired[bool]
 
 
 class StatusInfo(TypedDict):

--- a/tests/test_prusalink.py
+++ b/tests/test_prusalink.py
@@ -75,6 +75,25 @@ async def test_get_info(pl, respx_mock):
     assert result["nozzle_diameter"] == 0.4
 
 
+async def test_get_info_minimal_firmware(pl, respx_mock):
+    """Older firmware may omit several PrinterInfo fields."""
+    respx_mock.get(f"{HOST}/api/v1/info").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "serial": "CZPX4720X004XC34242",
+                "nozzle_diameter": 0.4,
+                "hostname": "prusa-mk3",
+            },
+        )
+    )
+    result = await pl.get_info()
+    assert result["serial"] == "CZPX4720X004XC34242"
+    assert "min_extrusion_temp" not in result
+    assert "network_error_chime" not in result
+    assert "farm_mode" not in result
+
+
 async def test_get_status(pl, respx_mock):
     respx_mock.get(f"{HOST}/api/v1/status").mock(
         return_value=httpx.Response(


### PR DESCRIPTION
Part of the 3.0.0 release per agreement in #167. Submitting as its own PR for review clarity.

## Why

The `/api/v1/info` endpoint actually omits absent fields rather than returning `None` — the original `T | None` typing was a lie that misled consumers into expecting `info["x"]` to always work. `NotRequired[T]` makes the contract honest: fields may be absent, and consumers must use `.get()` or membership checks.

Older Buddy firmware versions and edge configurations (e.g. printers not in farm mode) omit several fields. The docstring now documents this.

## Field types verified

All 12 field types verified against Prusa-Link-Web's authoritative [OpenAPI spec](https://github.com/prusa3d/Prusa-Link-Web/blob/master/spec/openapi.yaml) — no `required` list on the `Info` schema, so all properties are optional. Style matches the existing `NotRequired[T]` pattern on `VersionInfo`.

## Breaking change

Strict-typed consumers that index missing fields (`info["serial"]`) need to switch to `info.get("serial")`. Runtime behavior is unchanged — `info["serial"]` already raises `KeyError` today whenever the field is absent; the old typing just hid that fact.

The HA-side `prusalink` integration already accesses `PrinterInfo` defensively via `.get()` in most places, so no HA-side code changes are required.

## Test plan

- [x] `pytest tests/` — 23 passed (1 new `test_get_info_minimal_firmware` covering the NotRequired semantics)
- [x] flake8 / black / isort clean