### PR TITLE
Rename jobId to job_id on job-control methods

### DIFF
--- a/pyprusalink/__init__.py
+++ b/pyprusalink/__init__.py
@@ -30,24 +30,24 @@ class PrusaLink:
             async_client=async_client, host=host, username=username, password=password
         )
 
-    async def cancel_job(self, jobId: int) -> None:
+    async def cancel_job(self, job_id: int) -> None:
         """Cancel the current job."""
-        async with self.client.request("DELETE", f"/api/v1/job/{jobId}"):
+        async with self.client.request("DELETE", f"/api/v1/job/{job_id}"):
             pass
 
-    async def pause_job(self, jobId: int) -> None:
+    async def pause_job(self, job_id: int) -> None:
         """Pause a job."""
-        async with self.client.request("PUT", f"/api/v1/job/{jobId}/pause"):
+        async with self.client.request("PUT", f"/api/v1/job/{job_id}/pause"):
             pass
 
-    async def resume_job(self, jobId: int) -> None:
+    async def resume_job(self, job_id: int) -> None:
         """Resume a paused job."""
-        async with self.client.request("PUT", f"/api/v1/job/{jobId}/resume"):
+        async with self.client.request("PUT", f"/api/v1/job/{job_id}/resume"):
             pass
 
-    async def continue_job(self, jobId: int) -> None:
+    async def continue_job(self, job_id: int) -> None:
         """Continue a job after a timelapse capture."""
-        async with self.client.request("PUT", f"/api/v1/job/{jobId}/continue"):
+        async with self.client.request("PUT", f"/api/v1/job/{job_id}/continue"):
             pass
 
     async def get_version(self) -> VersionInfo:


### PR DESCRIPTION
Part of the 3.0.0 release per agreement in #167. Submitting as its own PR for review clarity.

## Why

The four job-control methods — `cancel_job`, `pause_job`, `resume_job`, `continue_job` — still use camelCase `jobId: int`, while `cancel_transfer(transfer_id: int)` (added more recently) already uses snake_case. Renaming brings them in line with PEP 8 and removes the cross-module inconsistency.

## Breaking change

Callers using keyword arguments (`cancel_job(jobId=42)`) will break. Home Assistant calls these methods positionally via `lambda api: api.cancel_job` in the button entity descriptions, so no HA-side changes are needed.

## Test plan

- [x] `pytest tests/` — 22 passed (existing positional-call tests cover the rename)
- [x] No `jobId` references remain in the codebase
- [x] flake8 / black / isort clean