### PR TITLE
Add Copilot code review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,26 @@
+# Copilot code review instructions
+
+- Start review comments with a short, one-sentence summary of the suggested fix.
+- Do not comment on code style, formatting, or linting issues — `black`, `isort`, `flake8`, and `mypy --strict` run in CI.
+- Suggest fixes at the library level rather than at the call site when the behaviour could affect downstream consumers.
+- A dependency version bump PR should only contain changes required for the version bump.
+
+# Project context
+
+`pyprusalink` is a thin async Python wrapper around the [PrusaLink v2 API](https://github.com/prusa3d/Prusa-Link-Web/blob/master/spec/openapi.yaml). The primary consumer is the [Home Assistant `prusalink` integration](https://www.home-assistant.io/integrations/prusalink/); other consumers are negligible.
+
+## Public API conventions
+
+- Public methods return `TypedDict`s declared in `pyprusalink/types.py`. Runtime validation is deliberately **not** performed at the library boundary; `KeyError` / `AttributeError` from missing fields propagates to the caller.
+- `response.json()` results are wrapped in `typing.cast(...)` against the declared `TypedDict`. This is the deliberate, lightweight alternative to runtime validation libraries (pydantic, msgspec); it is not a gap to be filled.
+- For optional fields on a `TypedDict`, prefer `NotRequired[T]` over `T | None`. The PrusaLink API actually omits absent fields rather than returning `null`, so `NotRequired` is the honest contract.
+- For methods that may not return data, use `T | None` for the return type (e.g. `get_transfer() -> Transfer | None`) rather than returning empty containers like `{}` or `[]`.
+
+## Test conventions
+
+- Tests live in `tests/`. HTTP is mocked with `respx`. Integration tests against a real printer are opt-in via the `integration` pytest marker; the default `pytest` invocation excludes them via `addopts = "-m 'not integration'"`.
+- Test and lint dependencies live in `[project.optional-dependencies]` under `test` and `lint` groups. There is intentionally no `requirements-test.txt`.
+
+## Versioning
+
+Semantic versioning. Breaking changes — including changes to `TypedDict` shapes that affect strict-typed consumers — require a major version bump.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,12 +2,26 @@
 
 - Start review comments with a short, one-sentence summary of the suggested fix.
 - Do not comment on code style, formatting, or linting issues — `black`, `isort`, `flake8`, and `mypy --strict` run in CI.
-- Suggest fixes at the library level rather than at the call site when the behaviour could affect downstream consumers.
 - A dependency version bump PR should only contain changes required for the version bump.
+
+## Helpful kinds of feedback
+
+- Type-soundness issues: `Any` leaks, `cast()` against the wrong type, `TypedDict` fields that lie about presence (`T | None` where the API actually omits the key).
+- Behaviour drift between the public API and what the upstream PrusaLink HTTP endpoint actually returns.
+- Async correctness: missing `await`, sync calls inside async functions, blocking I/O.
+- Test gaps for newly added behaviour, especially 204/404/409 paths and the no-resource case.
+
+## Less helpful kinds of feedback
+
+- Suggestions to introduce a runtime validation library (pydantic, msgspec) for the `response.json()` boundary — see "Public API conventions" below for the trade-off.
+- Generic "should we add retries / caching / backoff" suggestions on the HTTP layer; those are deliberately the consumer's concern.
+- Style/lint comments (CI covers these).
 
 # Project context
 
-`pyprusalink` is a thin async Python wrapper around the [PrusaLink v2 API](https://github.com/prusa3d/Prusa-Link-Web/blob/master/spec/openapi.yaml). The primary consumer is the [Home Assistant `prusalink` integration](https://www.home-assistant.io/integrations/prusalink/); other consumers are negligible.
+`pyprusalink` is an async Python client for the [PrusaLink HTTP API](https://github.com/prusa3d/Prusa-Link-Web/blob/master/spec/openapi.yaml). It covers both the current `/api/v1/...` endpoints and a few legacy paths (`/api/version`, `/api/printer`).
+
+The primary consumer is the [Home Assistant `prusalink` integration](https://www.home-assistant.io/integrations/prusalink/). API shape and breaking-change decisions are weighted toward what serves that integration best.
 
 ## Public API conventions
 


### PR DESCRIPTION
## Why

GitHub Copilot's PR reviewer fires on this repo (we saw it on #167) but it has no project-specific guidance, so it sometimes suggests things that don't match our conventions (e.g. swapping `cast()` for pydantic, commenting on style that CI already enforces). Adding `.github/copilot-instructions.md` is the standard way to give it that guidance.

## What's in the file

- **Review-style rules at the top** — one-sentence summaries, no style/lint comments, suggest fixes at the right layer, dependency-bump PRs stay focused.
- **Project context** — thin async wrapper, primary consumer is HA, source of truth is the Prusa-Link-Web OpenAPI spec.
- **Public API conventions** — `TypedDict`s with `cast()` at JSON boundaries is deliberate (not a gap to fill with pydantic/msgspec), `NotRequired[T]` over `T | None`, `T | None` for return types where the resource may be absent.
- **Test conventions** — `respx` for HTTP mocking, `pytest.mark.integration` opt-in, deps in `pyproject.toml`.
- **Versioning policy** — semver, TypedDict shape changes count as breaking.

## Timing note

Some of the conventions described (mypy strict, the `cast()` pattern, `PrinterInfo` migrating to `NotRequired`, `get_job() -> JobInfo | None`) are landing as part of the upcoming **3.0.0** release in #167 / #169 / #170. The file describes the end state; everything in it will be true on `main` once those merge. Happy to wait on this PR until after 3.0.0 lands if you'd prefer — but the file is harmless before then, and waiting just means Copilot keeps reviewing PRs without context.

## Suggested follow-up: enable automatic review

Right now Copilot review fires on this repo on demand but not automatically — for example #169 and #170 (both just opened) haven't been reviewed by Copilot. If you'd like reviews to run on every new PR, it can be enabled in repo Settings → **Code & automation** → **Copilot code review** → "Automatically review new pull requests". Up to you whether the trade-off is worth it.

## Test plan

- N/A — docs-only.
- Style/structure follows GitHub's [Copilot custom instructions docs](https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot) and `home-assistant/core`'s `.github/copilot-instructions.md`.