### PR TITLE
Add print file metadata parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,15 @@ async def main() -> None:
 
         job = await api.get_job()
         if job is not None:
-            print(f"{job['progress']:.0f}% — {job['file']['display_name']}")
+            job_file = job["file"]
+            display_name = job_file.get("display_name", job_file["name"])
+            print(f"{job['progress']:.0f}% — {display_name}")
+
+            if (refs := job_file.get("refs")) and (
+                download_path := refs.get("download")
+            ):
+                metadata = await api.get_file_metadata(download_path)
+                print(metadata.get("filament_type"), metadata.get("filament_used_g"))
 
 
 asyncio.run(main())
@@ -67,6 +75,7 @@ The username on bundled-firmware printers is `maker`. The password is the API ke
 | `continue_job(job_id)` | `None` | Continue after the printer enters the `ATTENTION` state (e.g. timelapse capture) |
 | `get_legacy_printer()` | `LegacyPrinterStatus` | `/api/printer` — legacy endpoint, used for `material` |
 | `get_file(path)` | `bytes` | Fetch raw resources such as thumbnails referenced from `JobFilePrint.refs` |
+| `get_file_metadata(path, max_bytes=16777216)` | `PrintFileMetadata` | Stream a print file up to `max_bytes` and parse known slicer metadata such as filament usage, material, cost, and estimated print time |
 
 ### Errors
 
@@ -77,6 +86,7 @@ All HTTP errors map to subclasses of `PrusaLinkError`:
 | `InvalidAuth` | 401 — wrong credentials |
 | `NotFound` | 404 — resource missing |
 | `Conflict` | 409 — action conflicts with current printer state (e.g. cancel while idle) |
+| `FileTooLarge` | Print file metadata download exceeds the configured `max_bytes` limit |
 
 ```python
 from pyprusalink.types import Conflict

--- a/pyprusalink/__init__.py
+++ b/pyprusalink/__init__.py
@@ -6,15 +6,20 @@ from typing import cast
 
 from httpx import AsyncClient
 from pyprusalink.client import ApiClient
+from pyprusalink.file_metadata import parse_file_metadata
 from pyprusalink.types import (
+    FileTooLarge,
     JobInfo,
     PrinterInfo,
     PrinterStatus,
+    PrintFileMetadata,
     Storage,
     Transfer,
     VersionInfo,
 )
 from pyprusalink.types_legacy import LegacyPrinterStatus
+
+MAX_FILE_METADATA_BYTES = 16 * 1024 * 1024
 
 
 class PrusaLink:
@@ -101,3 +106,30 @@ class PrusaLink:
         """Get a files such as Thumbnails or Icons. Path comes from the current job['file']['refs']['thumbnail']"""
         async with self.client.request("GET", path) as response:
             return await response.aread()
+
+    async def get_file_metadata(
+        self, path: str, max_bytes: int = MAX_FILE_METADATA_BYTES
+    ) -> PrintFileMetadata:
+        """Get known metadata from a print file."""
+        downloaded = bytearray()
+
+        async with self.client.stream_request("GET", path) as response:
+            if content_length := response.headers.get("content-length"):
+                try:
+                    expected_size = int(content_length)
+                except ValueError:
+                    expected_size = None
+
+                if expected_size is not None and expected_size > max_bytes:
+                    raise FileTooLarge(
+                        f"File {path} is {expected_size} bytes, "
+                        f"maximum is {max_bytes} bytes"
+                    )
+
+            async for chunk in response.aiter_bytes():
+                if len(downloaded) + len(chunk) > max_bytes:
+                    raise FileTooLarge(f"File {path} is larger than {max_bytes} bytes")
+
+                downloaded.extend(chunk)
+
+        return parse_file_metadata(bytes(downloaded))

--- a/pyprusalink/client.py
+++ b/pyprusalink/client.py
@@ -56,6 +56,19 @@ class ApiClient:
         self.host = host
         self._auth = DigestAuthWorkaround(username=username, password=password)
 
+    def _raise_for_response_status(self, response: Response) -> None:
+        """Raise library exceptions for known PrusaLink response statuses."""
+        if response.status_code == 401:
+            raise InvalidAuth()
+
+        if response.status_code == 409:
+            raise Conflict()
+
+        if response.status_code == 404:
+            raise NotFound()
+
+        response.raise_for_status()
+
     @asynccontextmanager
     async def request(
         self,
@@ -71,14 +84,21 @@ class ApiClient:
             method, url, json=json_data, auth=self._auth
         )
 
-        if response.status_code == 401:
-            raise InvalidAuth()
-
-        if response.status_code == 409:
-            raise Conflict()
-
-        if response.status_code == 404:
-            raise NotFound()
-
-        response.raise_for_status()
+        self._raise_for_response_status(response)
         yield response
+
+    @asynccontextmanager
+    async def stream_request(
+        self,
+        method: str,
+        path: str,
+        json_data: dict[str, Any] | None = None,
+    ) -> AsyncGenerator[Response, None]:
+        """Make a streaming request to the PrusaLink API."""
+        url = f"{self.host}{path}"
+
+        async with self._async_client.stream(
+            method, url, json=json_data, auth=self._auth
+        ) as response:
+            self._raise_for_response_status(response)
+            yield response

--- a/pyprusalink/file_metadata.py
+++ b/pyprusalink/file_metadata.py
@@ -1,0 +1,215 @@
+"""Helpers for parsing Prusa print file metadata."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import re
+from typing import Any
+import zlib
+
+from pyprusalink.types import PrintFileMetadata
+
+_BGCODE_MAGIC = b"GCDE"
+_BGCODE_FILE_HEADER_SIZE = 10
+_BGCODE_BLOCK_HEADER_SIZE = 8
+_BGCODE_COMPRESSED_BLOCK_HEADER_SIZE = 12
+_BGCODE_METADATA_BLOCK_TYPES = {0, 2, 3, 4}
+_BGCODE_GCODE_BLOCK_TYPE = 1
+_BGCODE_THUMBNAIL_BLOCK_TYPE = 5
+_BGCODE_NO_COMPRESSION = 0
+_BGCODE_DEFLATE_COMPRESSION = 1
+_BGCODE_INI_ENCODING = 0
+_BGCODE_CRC32_CHECKSUM = 1
+_BGCODE_CRC32_SIZE = 4
+_FLOAT_PATTERN = re.compile(r"-?\d+(?:\.\d+)?")
+_DURATION_PART_PATTERN = re.compile(r"(?P<value>\d+)\s*(?P<unit>[hms])")
+
+
+def parse_file_metadata(data: bytes) -> PrintFileMetadata:
+    """Parse known PrusaSlicer metadata from G-code or BG-code bytes."""
+    if data.startswith(_BGCODE_MAGIC):
+        return parse_metadata_mapping(_bgcode_metadata_to_mapping(data))
+
+    return parse_metadata_mapping(_gcode_metadata_to_mapping(data))
+
+
+def parse_metadata_mapping(metadata: Mapping[str, Any] | None) -> PrintFileMetadata:
+    """Normalize known Prusa print metadata keys."""
+    parsed: PrintFileMetadata = {}
+
+    if metadata is None:
+        return parsed
+
+    normalized = {_normalize_key(key): value for key, value in metadata.items()}
+
+    filament_used_g = _parse_float(normalized.get("filament used [g]"))
+    if filament_used_g is not None:
+        parsed["filament_used_g"] = filament_used_g
+
+    filament_used_mm = _parse_float(normalized.get("filament used [mm]"))
+    if filament_used_mm is not None:
+        parsed["filament_used_mm"] = filament_used_mm
+
+    filament_used_cm3 = _parse_float(normalized.get("filament used [cm3]"))
+    if filament_used_cm3 is not None:
+        parsed["filament_used_cm3"] = filament_used_cm3
+
+    filament_cost = _parse_float(normalized.get("filament cost"))
+    if filament_cost is not None:
+        parsed["filament_cost"] = filament_cost
+
+    filament_type = normalized.get("filament_type")
+    if filament_type is not None:
+        parsed["filament_type"] = str(filament_type).strip()
+
+    estimated_printing_time_normal = _parse_duration(
+        str(normalized.get("estimated printing time (normal mode)", ""))
+    )
+    if estimated_printing_time_normal is not None:
+        parsed["estimated_printing_time_normal"] = estimated_printing_time_normal
+
+    estimated_printing_time_silent = _parse_duration(
+        str(normalized.get("estimated printing time (silent mode)", ""))
+    )
+    if estimated_printing_time_silent is not None:
+        parsed["estimated_printing_time_silent"] = estimated_printing_time_silent
+
+    return parsed
+
+
+def _gcode_metadata_to_mapping(data: bytes) -> dict[str, str]:
+    """Extract key-value metadata lines from text G-code."""
+    return _metadata_lines_to_mapping(data.decode("utf-8", errors="ignore"))
+
+
+def _bgcode_metadata_to_mapping(data: bytes) -> dict[str, str]:
+    """Extract INI-encoded metadata blocks from BG-code."""
+    metadata: dict[str, str] = {}
+    checksum_size = _bgcode_checksum_size(_read_uint16(data, 8))
+    offset = _BGCODE_FILE_HEADER_SIZE
+
+    while offset + _BGCODE_BLOCK_HEADER_SIZE <= len(data):
+        block_type = _read_uint16(data, offset)
+        compression = _read_uint16(data, offset + 2)
+        uncompressed_size = _read_uint32(data, offset + 4)
+
+        if block_type == _BGCODE_GCODE_BLOCK_TYPE:
+            break
+
+        if compression == _BGCODE_NO_COMPRESSION:
+            block_data_size = uncompressed_size
+            offset += _BGCODE_BLOCK_HEADER_SIZE
+        else:
+            if offset + _BGCODE_COMPRESSED_BLOCK_HEADER_SIZE > len(data):
+                break
+
+            block_data_size = _read_uint32(data, offset + 8)
+            offset += _BGCODE_COMPRESSED_BLOCK_HEADER_SIZE
+
+        parameters_size = _bgcode_block_parameters_size(block_type)
+        if offset + parameters_size + block_data_size + checksum_size > len(data):
+            break
+
+        encoding = _read_uint16(data, offset) if parameters_size >= 2 else None
+        offset += parameters_size
+
+        block_data = data[offset : offset + block_data_size]
+        offset += block_data_size + checksum_size
+
+        if (
+            block_type not in _BGCODE_METADATA_BLOCK_TYPES
+            or encoding != _BGCODE_INI_ENCODING
+        ):
+            continue
+
+        if (metadata_block := _decode_bgcode_block(block_data, compression)) is None:
+            continue
+
+        metadata.update(_metadata_lines_to_mapping(metadata_block))
+
+    return metadata
+
+
+def _metadata_lines_to_mapping(text: str) -> dict[str, str]:
+    """Extract key-value metadata lines from INI-like metadata text."""
+    metadata: dict[str, str] = {}
+    for line in text.splitlines():
+        clean_line = line.strip().lstrip(";").strip()
+        if "=" not in clean_line:
+            continue
+
+        key, value = clean_line.split("=", 1)
+        metadata[_normalize_key(key)] = value.strip()
+
+    return metadata
+
+
+def _decode_bgcode_block(data: bytes, compression: int) -> str | None:
+    """Decode a BG-code metadata block."""
+    if compression == _BGCODE_NO_COMPRESSION:
+        decoded = data
+    elif compression == _BGCODE_DEFLATE_COMPRESSION:
+        try:
+            decoded = zlib.decompress(data)
+        except zlib.error:
+            return None
+    else:
+        return None
+
+    return decoded.decode("utf-8", errors="replace")
+
+
+def _bgcode_block_parameters_size(block_type: int) -> int:
+    """Return the size of the block parameters."""
+    if block_type == _BGCODE_THUMBNAIL_BLOCK_TYPE:
+        return 6
+
+    return 2
+
+
+def _bgcode_checksum_size(checksum_type: int) -> int:
+    """Return the size of the block checksum."""
+    if checksum_type == _BGCODE_CRC32_CHECKSUM:
+        return _BGCODE_CRC32_SIZE
+
+    return 0
+
+
+def _read_uint16(data: bytes, offset: int) -> int:
+    return int.from_bytes(data[offset : offset + 2], "little")
+
+
+def _read_uint32(data: bytes, offset: int) -> int:
+    return int.from_bytes(data[offset : offset + 4], "little")
+
+
+def _normalize_key(key: Any) -> str:
+    return " ".join(str(key).strip().lower().split())
+
+
+def _parse_float(value: Any) -> float | None:
+    if isinstance(value, int | float):
+        return float(value)
+
+    match = _FLOAT_PATTERN.search(str(value))
+    if match is None:
+        return None
+
+    return float(match.group(0))
+
+
+def _parse_duration(value: str) -> int | None:
+    total_seconds = 0
+
+    for match in _DURATION_PART_PATTERN.finditer(value.lower()):
+        amount = int(match.group("value"))
+        unit = match.group("unit")
+
+        if unit == "h":
+            total_seconds += amount * 3600
+        elif unit == "m":
+            total_seconds += amount * 60
+        else:
+            total_seconds += amount
+
+    return total_seconds or None

--- a/pyprusalink/types.py
+++ b/pyprusalink/types.py
@@ -20,6 +20,10 @@ class NotFound(PrusaLinkError):
     """Error to indicate the requested resource was not found. (404)"""
 
 
+class FileTooLarge(PrusaLinkError):
+    """Error to indicate the requested file is too large to process."""
+
+
 class Capabilities(TypedDict):
     """API Capabilities"""
 
@@ -161,22 +165,34 @@ class PrinterStatus(TypedDict):
 class PrintFileRefs(TypedDict):
     """Additional Files for the current Job"""
 
-    download: str | None
-    icon: str | None
-    thumbnail: str | None
+    download: NotRequired[str]
+    icon: NotRequired[str]
+    thumbnail: NotRequired[str]
+
+
+class PrintFileMetadata(TypedDict, total=False):
+    """Known metadata parsed from a Prusa print file."""
+
+    filament_used_g: float
+    filament_used_mm: float
+    filament_used_cm3: float
+    filament_cost: float
+    filament_type: str
+    estimated_printing_time_normal: int
+    estimated_printing_time_silent: int
 
 
 class JobFilePrint(TypedDict):
     """Currently printed file informations."""
 
     name: str
-    display_name: str | None
     path: str
-    display_path: str | None
-    size: int | None
     m_timestamp: int
-    meta: dict[str, Any] | None
-    refs: PrintFileRefs | None
+    display_name: NotRequired[str]
+    display_path: NotRequired[str]
+    size: NotRequired[int]
+    meta: NotRequired[dict[str, Any]]
+    refs: NotRequired[PrintFileRefs]
 
 
 class JobInfo(TypedDict):

--- a/tests/test_file_metadata.py
+++ b/tests/test_file_metadata.py
@@ -1,0 +1,121 @@
+"""Tests for Prusa print file metadata parsing."""
+
+import struct
+import zlib
+
+from pyprusalink.file_metadata import parse_file_metadata, parse_metadata_mapping
+
+
+def _bgcode_block(
+    block_type: int, payload: bytes, encoding: int = 0, compression: int = 0
+) -> bytes:
+    if compression == 1:
+        block_data = zlib.compress(payload)
+        header = struct.pack(
+            "<HHII", block_type, compression, len(payload), len(block_data)
+        )
+    else:
+        block_data = payload
+        header = struct.pack("<HHI", block_type, compression, len(payload))
+
+    return header + struct.pack("<H", encoding) + block_data
+
+
+def test_parse_file_metadata_from_gcode_comments():
+    data = b"""
+; printer_model=COREONE
+; filament_type=PLA
+; filament used [mm]=8184.17
+; filament used [g]=24.41
+; filament cost=0.68
+; filament used [cm3]=19.69
+; estimated printing time (normal mode)=1h 3m 31s
+; estimated printing time (silent mode)=1h 10m 56s
+"""
+
+    result = parse_file_metadata(data)
+
+    assert result == {
+        "filament_type": "PLA",
+        "filament_used_mm": 8184.17,
+        "filament_used_g": 24.41,
+        "filament_cost": 0.68,
+        "filament_used_cm3": 19.69,
+        "estimated_printing_time_normal": 3811,
+        "estimated_printing_time_silent": 4256,
+    }
+
+
+def test_parse_file_metadata_from_bgcode_binary_content():
+    metadata = b"\n".join(
+        (
+            b"printer_model=COREONE",
+            b"filament_type=PETG",
+            b"filament used [mm]=1234.5",
+            b"filament used [g]=3.21",
+            b"estimated printing time (normal mode)=2h 4m",
+        )
+    )
+    data = (
+        b"GCDE"
+        + struct.pack("<IH", 1, 0)
+        + _bgcode_block(4, metadata)
+        + _bgcode_block(1, b"G1 X10")
+    )
+
+    result = parse_file_metadata(data)
+
+    assert result["filament_type"] == "PETG"
+    assert result["filament_used_mm"] == 1234.5
+    assert result["filament_used_g"] == 3.21
+    assert result["estimated_printing_time_normal"] == 7440
+
+
+def test_parse_file_metadata_from_deflated_bgcode_metadata_block():
+    metadata = b"filament_type=PLA\nfilament used [g]=24.41"
+    data = (
+        b"GCDE" + struct.pack("<IH", 1, 0) + _bgcode_block(4, metadata, compression=1)
+    )
+
+    result = parse_file_metadata(data)
+
+    assert result == {
+        "filament_type": "PLA",
+        "filament_used_g": 24.41,
+    }
+
+
+def test_parse_file_metadata_from_multiple_bgcode_metadata_blocks():
+    data = (
+        b"GCDE"
+        + struct.pack("<IH", 1, 0)
+        + _bgcode_block(3, b"filament_type=PETG")
+        + _bgcode_block(4, b"filament used [g]=12.34")
+    )
+
+    result = parse_file_metadata(data)
+
+    assert result == {
+        "filament_type": "PETG",
+        "filament_used_g": 12.34,
+    }
+
+
+def test_parse_file_metadata_ignores_missing_values():
+    assert parse_file_metadata(b"; printer_model=COREONE\nG1 X10 Y10") == {}
+
+
+def test_parse_metadata_mapping_normalizes_values():
+    result = parse_metadata_mapping(
+        {
+            " Filament Used [G] ": "24.41 g",
+            "FILAMENT_TYPE": " PLA ",
+            "Estimated Printing Time (Normal Mode)": "31s",
+        }
+    )
+
+    assert result == {
+        "filament_used_g": 24.41,
+        "filament_type": "PLA",
+        "estimated_printing_time_normal": 31,
+    }

--- a/tests/test_prusalink.py
+++ b/tests/test_prusalink.py
@@ -1,6 +1,8 @@
 """Happy-path tests for PrusaLink public API methods."""
 
 import httpx
+from pyprusalink.types import FileTooLarge
+import pytest
 
 HOST = "http://printer.local"
 
@@ -184,8 +186,6 @@ async def test_get_job(pl, respx_mock):
                     "size": 2393142,
                     "m_timestamp": 1648042843,
                     "refs": {
-                        "download": None,
-                        "icon": None,
                         "thumbnail": "/api/thumbnails/local/test.gcode.orig.png",
                     },
                 },
@@ -309,3 +309,36 @@ async def test_get_file(pl, respx_mock):
     )
     result = await pl.get_file("/api/thumbnails/test.png")
     assert result == thumbnail_bytes
+
+
+async def test_get_file_metadata(pl, respx_mock):
+    print_file = b"""
+; filament_type=PLA
+; filament used [g]=24.41
+; filament used [mm]=8184.17
+; estimated printing time (normal mode)=1h 3m 31s
+"""
+    respx_mock.get(f"{HOST}/usb/test.bgcode").mock(
+        return_value=httpx.Response(200, content=print_file)
+    )
+
+    result = await pl.get_file_metadata("/usb/test.bgcode")
+
+    assert result == {
+        "filament_type": "PLA",
+        "filament_used_g": 24.41,
+        "filament_used_mm": 8184.17,
+        "estimated_printing_time_normal": 3811,
+    }
+
+
+async def test_get_file_metadata_rejects_large_files(pl, respx_mock):
+    print_file = b"; filament_type=PLA\n"
+    respx_mock.get(f"{HOST}/usb/large.bgcode").mock(
+        return_value=httpx.Response(
+            200, content=print_file, headers={"content-length": "18"}
+        )
+    )
+
+    with pytest.raises(FileTooLarge):
+        await pl.get_file_metadata("/usb/large.bgcode", max_bytes=17)


### PR DESCRIPTION
## Summary

Adds parsing for known PrusaSlicer print file metadata from G-code/BG-code files.

Parsed fields include filament usage, filament type, filament cost, and estimated print times. The metadata download path is streamed and capped with `max_bytes` to avoid reading unexpectedly large print files into memory.

This is needed by Home Assistant because current PrusaLink job responses may not include `job.file.meta` on real hardware.

## Testing

- `python -m pytest`
- `black --check pyprusalink tests`
- `isort --check pyprusalink tests`
- `flake8 pyprusalink tests`
- `mypy`
- Smoke-tested against a Prusa Core One where `/api/v1/job` did not include `file.meta`, but downloading the active `.bgcode` file exposed the expected metadata.